### PR TITLE
feat(quickfix-renderer): implement CPU-based adjustment pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,12 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "bit_field"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,58 +70,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "exr"
-version = "1.74.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
-dependencies = [
- "bit_field",
- "half",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,24 +89,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "gif"
-version = "0.13.3"
+name = "getrandom"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
-dependencies = [
- "color_quant",
- "weezl",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "crunchy",
- "zerocopy",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -176,13 +108,9 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "exr",
- "gif",
  "jpeg-decoder",
  "num-traits",
  "png",
- "qoi",
- "tiff",
 ]
 
 [[package]]
@@ -196,9 +124,6 @@ name = "jpeg-decoder"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "js-sys"
@@ -211,20 +136,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "lebe"
-version = "0.5.3"
+name = "libc"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.10"
+name = "libm"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "memchr"
@@ -243,43 +164,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -302,6 +193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,22 +211,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "qoi"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
 name = "quickfix-renderer"
 version = "0.1.0"
 dependencies = [
  "console_error_panic_hook",
  "image",
- "ndarray",
+ "rand",
+ "rand_chacha",
+ "rand_distr",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "wasm-bindgen",
  "web-sys",
@@ -342,29 +236,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "either",
- "rayon-core",
+ "libc",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
-name = "rayon-core"
-version = "1.13.0"
+name = "rand_chacha"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]
@@ -387,6 +295,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -429,12 +348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
 name = "syn"
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,21 +359,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiff"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -518,12 +426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
 name = "zerocopy"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,13 +443,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
 ]

--- a/quickfix-renderer/Cargo.toml
+++ b/quickfix-renderer/Cargo.toml
@@ -16,9 +16,12 @@ webgpu = []
 wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde-wasm-bindgen = "0.6"
 console_error_panic_hook = "0.1"
-image = { version = "0.24", optional = true }
-ndarray = { version = "0.15", optional = true }
+image = { version = "0.24", default-features = false, features = ["png", "jpeg"] } # minimal features
+rand = "0.8"
+rand_chacha = "0.3"
+rand_distr = "0.4"
 
 [dependencies.web-sys]
 version = "0.3"

--- a/quickfix-renderer/src/lib.rs
+++ b/quickfix-renderer/src/lib.rs
@@ -1,32 +1,51 @@
+use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
-#[wasm_bindgen]
-pub fn init() {
-    console_error_panic_hook::set_once();
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CropSettings {
+    pub rotation: Option<f32>,
+    pub aspect_ratio: Option<f32>,
 }
 
-#[wasm_bindgen]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExposureSettings {
+    pub exposure: Option<f32>,
+    pub contrast: Option<f32>,
+    pub highlights: Option<f32>,
+    pub shadows: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ColorSettings {
+    pub temperature: Option<f32>,
+    pub tint: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GrainSettings {
+    pub amount: f32,
+    pub size: String, // "fine", "medium", "coarse"
+    pub seed: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GeometrySettings {
+    pub vertical: Option<f32>,
+    pub horizontal: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct QuickFixAdjustments {
-    pub exposure: f32,
-    pub contrast: f32,
-    // Add other fields as needed
+    pub crop: Option<CropSettings>,
+    pub exposure: Option<ExposureSettings>,
+    pub color: Option<ColorSettings>,
+    pub grain: Option<GrainSettings>,
+    pub geometry: Option<GeometrySettings>,
 }
 
-#[wasm_bindgen]
 impl QuickFixAdjustments {
-    #[wasm_bindgen(constructor)]
     pub fn new() -> QuickFixAdjustments {
-        QuickFixAdjustments {
-            exposure: 0.0,
-            contrast: 0.0,
-        }
-    }
-}
-
-impl Default for QuickFixAdjustments {
-    fn default() -> Self {
-        Self::new()
+        QuickFixAdjustments::default()
     }
 }
 
@@ -35,19 +54,60 @@ pub fn process_frame(
     data: &mut [u8],
     width: u32,
     height: u32,
-    adjustments: &QuickFixAdjustments,
-) -> Result<(), JsValue> {
-    // Placeholder: No-op for now, just logging
-    web_sys::console::log_1(
-        &format!(
-            "Processing frame {}x{} with adjustments: {:?}",
-            width, height, adjustments
-        )
-        .into(),
-    );
+    adjustments: JsValue,
+) -> Result<Vec<u8>, JsValue> {
+    let adjustments: QuickFixAdjustments = serde_wasm_bindgen::from_value(adjustments)?;
+    operations::process_frame_internal(data, width, height, &adjustments)
+        .map_err(|e| JsValue::from_str(&e))
+}
 
-    // In the future, we will modify 'data' in place here based on features.
-    let _ = data; // Suppress unused variable warning
+pub mod operations;
 
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialization() {
+        let json = r#"{
+            "crop": {"rotation": 90.0},
+            "exposure": {"exposure": 1.0},
+            "grain": {"amount": 0.5, "size": "fine", "seed": 123}
+        }"#;
+        let adj: QuickFixAdjustments = serde_json::from_str(json).unwrap();
+        assert_eq!(adj.crop.unwrap().rotation, Some(90.0));
+        assert_eq!(adj.exposure.unwrap().exposure, Some(1.0));
+        assert_eq!(adj.grain.as_ref().unwrap().amount, 0.5);
+        assert_eq!(adj.grain.as_ref().unwrap().seed, Some(123));
+    }
+
+    #[test]
+    fn test_deterministic_grain() {
+        let width = 100;
+        let height = 100;
+        let mut data1 = vec![128u8; (width * height * 4) as usize];
+        let mut data2 = vec![128u8; (width * height * 4) as usize];
+
+        let mut adj = QuickFixAdjustments::default();
+        adj.grain = Some(GrainSettings {
+            amount: 0.5,
+            size: "medium".to_string(),
+            seed: Some(555),
+        });
+
+        let res1 = operations::process_frame_internal(&mut data1, width, height, &adj).unwrap();
+        let res2 = operations::process_frame_internal(&mut data2, width, height, &adj).unwrap();
+
+        assert_eq!(res1, res2, "Grain output should be identical for same seed");
+    }
+
+    #[test]
+    fn test_pipeline_no_panic() {
+        let width = 10;
+        let height = 10;
+        let mut data = vec![0u8; (width * height * 4) as usize];
+        let adj = QuickFixAdjustments::default();
+        let res = operations::process_frame_internal(&mut data, width, height, &adj);
+        assert!(res.is_ok());
+    }
 }

--- a/quickfix-renderer/src/operations.rs
+++ b/quickfix-renderer/src/operations.rs
@@ -1,0 +1,398 @@
+use crate::{
+    ColorSettings, CropSettings, ExposureSettings, GeometrySettings, GrainSettings,
+    QuickFixAdjustments,
+};
+use image::{ImageBuffer, Pixel, Rgba, RgbaImage};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use rand_distr::{Distribution, Normal};
+use std::cmp::{max, min};
+
+// Helper to clamp values
+fn clamp(v: f32, min_val: f32, max_val: f32) -> f32 {
+    v.max(min_val).min(max_val)
+}
+
+fn clamp_u8(v: f32) -> u8 {
+    clamp(v, 0.0, 255.0) as u8
+}
+
+pub fn process_frame_internal(
+    data: &mut [u8],
+    width: u32,
+    height: u32,
+    adjustments: &QuickFixAdjustments,
+) -> Result<Vec<u8>, String> {
+    // Convert raw bytes to ImageBuffer
+    let mut img: RgbaImage =
+        ImageBuffer::from_raw(width, height, data.to_vec()).ok_or("Invalid buffer size")?;
+
+    // 1. Geometry
+    if let Some(geo) = &adjustments.geometry {
+        img = apply_geometry(&img, geo);
+    }
+
+    // 2. Crop/Rotate
+    if let Some(crop) = &adjustments.crop {
+        img = apply_crop_rotate(&img, crop);
+    }
+
+    // 3. Exposure
+    if let Some(exp) = &adjustments.exposure {
+        apply_exposure_in_place(&mut img, exp);
+    }
+
+    // 4. Color
+    if let Some(col) = &adjustments.color {
+        apply_color_balance_in_place(&mut img, col);
+    }
+
+    // 5. Grain
+    if let Some(grain) = &adjustments.grain {
+        apply_grain_in_place(&mut img, grain);
+    }
+
+    Ok(img.into_raw())
+}
+
+// Bicubic interpolation helper
+fn cubic_hermite(a: f32, b: f32, c: f32, d: f32, t: f32) -> f32 {
+    let a_val = -a / 2.0 + (3.0 * b) / 2.0 - (3.0 * c) / 2.0 + d / 2.0;
+    let b_val = a - (5.0 * b) / 2.0 + 2.0 * c - d / 2.0;
+    let c_val = -a / 2.0 + c / 2.0;
+    let d_val = b;
+
+    a_val * t * t * t + b_val * t * t + c_val * t + d_val
+}
+
+fn get_pixel_clamped(img: &RgbaImage, x: i32, y: i32) -> Rgba<u8> {
+    let w = img.width() as i32;
+    let h = img.height() as i32;
+    let x = x.max(0).min(w - 1);
+    let y = y.max(0).min(h - 1);
+    *img.get_pixel(x as u32, y as u32)
+}
+
+fn sample_bicubic(img: &RgbaImage, u: f32, v: f32) -> Rgba<u8> {
+    let x = u - 0.5;
+    let y = v - 0.5;
+    let x_int = x.floor() as i32;
+    let y_int = y.floor() as i32;
+    let x_frac = x - x.floor();
+    let y_frac = y - y.floor();
+
+    let mut result = [0.0; 4];
+
+    for c in 0..4 {
+        let mut col_values = [0.0; 4];
+        for (i, dy) in (-1..=2).enumerate() {
+            let mut row_values = [0.0; 4];
+            for (j, dx) in (-1..=2).enumerate() {
+                let px = get_pixel_clamped(img, x_int + dx, y_int + dy);
+                row_values[j] = px[c] as f32;
+            }
+            col_values[i] = cubic_hermite(
+                row_values[0],
+                row_values[1],
+                row_values[2],
+                row_values[3],
+                x_frac,
+            );
+        }
+        result[c] = cubic_hermite(
+            col_values[0],
+            col_values[1],
+            col_values[2],
+            col_values[3],
+            y_frac,
+        );
+    }
+
+    Rgba([
+        clamp_u8(result[0]),
+        clamp_u8(result[1]),
+        clamp_u8(result[2]),
+        clamp_u8(result[3]),
+    ])
+}
+
+fn apply_geometry(img: &RgbaImage, settings: &GeometrySettings) -> RgbaImage {
+    let v = clamp(settings.vertical.unwrap_or(0.0), -1.0, 1.0);
+    let h = clamp(settings.horizontal.unwrap_or(0.0), -1.0, 1.0);
+
+    if v.abs() < 1e-5 && h.abs() < 1e-5 {
+        return img.clone();
+    }
+
+    let width = img.width();
+    let height = img.height();
+    let max_x_offset = width as f32 * 0.25;
+    let max_y_offset = height as f32 * 0.25;
+
+    let top_inset = v * max_x_offset;
+    let bottom_inset = -v * max_x_offset;
+    let left_y = h * max_y_offset;
+    let right_y = -h * max_y_offset;
+
+    // Calculate quad corners (source coordinates mapped to destination)
+    let clamp_x = |val: f32| -> f32 { val.max(-max_x_offset).min(width as f32 + max_x_offset) };
+    let clamp_y = |val: f32| -> f32 { val.max(-max_y_offset).min(height as f32 + max_y_offset) };
+
+    let ul = (clamp_x(0.0 + top_inset), clamp_y(0.0 + left_y));
+    let ll = (clamp_x(0.0 + bottom_inset), clamp_y(height as f32 - left_y));
+    let lr = (clamp_x(width as f32 - bottom_inset), clamp_y(height as f32 - right_y));
+    let ur = (clamp_x(width as f32 - top_inset), clamp_y(0.0 + right_y));
+    
+    // Calculate homography H such that H * [x, y, 1]^T ~ [u, v, 1]^T
+    // This is standard. I'll use a Gaussian elimination solver for 8x8.
+    // Or better, since source is a rectangle aligned with axes, there are simpler formulas.
+    // But let's just stick to a general solver for robustness.
+    // Actually, to save code size and complexity, I'll use the "bilinear interpolation of corners" for the coordinate mapping.
+    // It produces a slightly different look than perspective (lines don't stay straight), but it's much simpler.
+    // Wait, "Geometry" tool usually expects straight lines to stay straight.
+    // I should really try to do perspective.
+    
+    // Let's assume for now I will use a simple perspective setup.
+    // Since I can't easily import a solver, I'll use a crate if I can? `projection` crate?
+    // No, I'll stick to the bilinear coordinate mapping for this iteration. 
+    // It's a "Quick Fix" renderer.
+    // "Geometry: horizontal/vertical in [-1, 1], warps quad with up to ~25% inset per axis"
+    // The Python code uses `Image.QUAD`.
+    
+    let mut new_img = RgbaImage::new(width, height);
+    
+    // Bilinear coordinate interpolation (Approximation of perspective)
+    // P(u,v) = (1-x)(1-y)UL + x(1-y)UR + (1-x)yLL + xyLR
+    // where x, y are normalized 0..1
+    
+    for y in 0..height {
+        let v_ratio = y as f32 / height as f32;
+        for x in 0..width {
+            let u_ratio = x as f32 / width as f32;
+            
+            // Interpolate X coordinate
+            let top_x = ul.0 + (ur.0 - ul.0) * u_ratio;
+            let bottom_x = ll.0 + (lr.0 - ll.0) * u_ratio;
+            let src_x = top_x + (bottom_x - top_x) * v_ratio;
+            
+            // Interpolate Y coordinate
+            let left_y = ul.1 + (ll.1 - ul.1) * v_ratio;
+            let right_y = ur.1 + (lr.1 - ur.1) * v_ratio;
+            let src_y = left_y + (right_y - left_y) * u_ratio;
+            
+            // Sample
+            let px = sample_bicubic(img, src_x, src_y);
+            new_img.put_pixel(x, y, px);
+        }
+    }
+    
+    new_img
+}
+
+fn apply_crop_rotate(img: &RgbaImage, settings: &CropSettings) -> RgbaImage {
+    let mut result = img.clone();
+
+    // Rotation
+    if let Some(rot) = settings.rotation {
+        if rot.abs() > 1e-5 {
+            // Python: result.rotate(-settings.rotation, resample=Image.Resampling.BICUBIC, expand=False)
+            // We need to rotate around center, keeping size same.
+            // We can reuse the same sampling logic as Geometry!
+            // Just map output pixels to input pixels via rotation matrix.
+            
+            let angle_rad = -rot.to_radians(); // Python uses degrees
+            let cos_a = angle_rad.cos();
+            let sin_a = angle_rad.sin();
+            
+            let w = result.width();
+            let h = result.height();
+            let cx = w as f32 / 2.0;
+            let cy = h as f32 / 2.0;
+            
+            let mut rotated = RgbaImage::new(w, h);
+            
+            for y in 0..h {
+                for x in 0..w {
+                    // Output coords relative to center
+                    let dx = x as f32 - cx;
+                    let dy = y as f32 - cy;
+                    
+                    // Rotate backwards to find source
+                    // x_src = x_dst * cos - y_dst * sin
+                    // y_src = x_dst * sin + y_dst * cos
+                    // (Inverse rotation is -angle)
+                    // Wait, we want to map Dest -> Source.
+                    // If we rotate image by Theta, then Source = Rotate(-Theta) * Dest
+                    // So we use -angle_rad.
+                    // But `angle_rad` is already `-rot`.
+                    // So we use `-angle_rad` = `rot`.
+                    
+                    let src_dx = dx * cos_a + dy * sin_a;
+                    let src_dy = -dx * sin_a + dy * cos_a;
+                    
+                    let src_x = src_dx + cx;
+                    let src_y = src_dy + cy;
+                    
+                    rotated.put_pixel(x, y, sample_bicubic(&result, src_x, src_y));
+                }
+            }
+            result = rotated;
+        }
+    }
+
+    // Aspect Ratio Crop
+    if let Some(ar) = settings.aspect_ratio {
+        if ar > 0.0 {
+            let (w, h) = result.dimensions();
+            let current_ratio = w as f32 / h as f32;
+            
+            if (current_ratio - ar).abs() > 1e-3 {
+                let (new_w, new_h) = if current_ratio > ar {
+                    // Too wide, crop width
+                    let nw = (h as f32 * ar) as u32;
+                    (nw, h)
+                } else {
+                    // Too tall, crop height
+                    let nh = (w as f32 / ar) as u32;
+                    (w, nh)
+                };
+
+                let x = (w - new_w) / 2;
+                let y = (h - new_h) / 2;
+                
+                result = image::imageops::crop_imm(&result, x, y, new_w, new_h).to_image();
+            }
+        }
+    }
+
+    result
+}
+
+fn apply_exposure_in_place(img: &mut RgbaImage, settings: &ExposureSettings) {
+    let exposure = settings.exposure.unwrap_or(0.0);
+    let contrast = settings.contrast.unwrap_or(1.0);
+    let highlights = settings.highlights.unwrap_or(0.0);
+    let shadows = settings.shadows.unwrap_or(0.0);
+
+    let exposure_factor = 2.0_f32.powf(exposure);
+
+    for pixel in img.pixels_mut() {
+        let r = pixel[0] as f32 / 255.0;
+        let g = pixel[1] as f32 / 255.0;
+        let b = pixel[2] as f32 / 255.0;
+        let a = pixel[3];
+
+        // Exposure
+        let mut r = r * exposure_factor;
+        let mut g = g * exposure_factor;
+        let mut b = b * exposure_factor;
+
+        // Contrast
+        if (contrast - 1.0).abs() > 1e-3 {
+            r = (r - 0.5) * contrast + 0.5;
+            g = (g - 0.5) * contrast + 0.5;
+            b = (b - 0.5) * contrast + 0.5;
+        }
+
+        // Highlights / Shadows
+        if highlights != 0.0 {
+            let hm_r = clamp((r - 0.5) * 2.0, 0.0, 1.0);
+            let hm_g = clamp((g - 0.5) * 2.0, 0.0, 1.0);
+            let hm_b = clamp((b - 0.5) * 2.0, 0.0, 1.0);
+            
+            r += hm_r * highlights * 0.5;
+            g += hm_g * highlights * 0.5;
+            b += hm_b * highlights * 0.5;
+        }
+
+        if shadows != 0.0 {
+            let sm_r = clamp((0.5 - r) * 2.0, 0.0, 1.0);
+            let sm_g = clamp((0.5 - g) * 2.0, 0.0, 1.0);
+            let sm_b = clamp((0.5 - b) * 2.0, 0.0, 1.0);
+
+            r += sm_r * shadows * 0.5;
+            g += sm_g * shadows * 0.5;
+            b += sm_b * shadows * 0.5;
+        }
+
+        pixel[0] = clamp_u8(r * 255.0);
+        pixel[1] = clamp_u8(g * 255.0);
+        pixel[2] = clamp_u8(b * 255.0);
+        pixel[3] = a;
+    }
+}
+
+fn apply_color_balance_in_place(img: &mut RgbaImage, settings: &ColorSettings) {
+    let temp = clamp(settings.temperature.unwrap_or(0.0), -1.0, 1.0);
+    let tint = clamp(settings.tint.unwrap_or(0.0), -1.0, 1.0);
+
+    if temp.abs() < 1e-5 && tint.abs() < 1e-5 {
+        return;
+    }
+
+    let temp_r = 1.0 + temp * 0.25;
+    let temp_b = 1.0 - temp * 0.25;
+    let tint_g = 1.0 - tint * 0.2;
+    let tint_rb = 1.0 + tint * 0.1;
+
+    let f_r = temp_r * tint_rb;
+    let f_g = tint_g;
+    let f_b = temp_b * tint_rb;
+
+    for pixel in img.pixels_mut() {
+        let r = pixel[0] as f32;
+        let g = pixel[1] as f32;
+        let b = pixel[2] as f32;
+
+        pixel[0] = clamp_u8(r * f_r);
+        pixel[1] = clamp_u8(g * f_g);
+        pixel[2] = clamp_u8(b * f_b);
+    }
+}
+
+fn apply_grain_in_place(img: &mut RgbaImage, settings: &GrainSettings) {
+    if settings.amount <= 0.0 {
+        return;
+    }
+
+    let scale = match settings.size.as_str() {
+        "medium" => 2,
+        "coarse" => 4,
+        _ => 1,
+    };
+
+    let (width, height) = img.dimensions();
+    let noise_w = max(1, (width + scale - 1) / scale);
+    let noise_h = max(1, (height + scale - 1) / scale);
+
+    let sigma = clamp(settings.amount, 0.0, 1.0) * 25.0;
+    
+    // Deterministic RNG
+    let seed = settings.seed.unwrap_or(42); 
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let normal = Normal::new(0.0, sigma).unwrap();
+
+    // Generate noise buffer
+    let mut noise_buffer = vec![0.0f32; (noise_w * noise_h) as usize];
+    for x in noise_buffer.iter_mut() {
+        *x = normal.sample(&mut rng);
+    }
+
+    // Apply noise
+    for y in 0..height {
+        for x in 0..width {
+            let nx = x / scale;
+            let ny = y / scale;
+            let noise_val = noise_buffer[(ny * noise_w + nx) as usize];
+
+            let pixel = img.get_pixel_mut(x, y);
+            let r = pixel[0] as f32 + noise_val;
+            let g = pixel[1] as f32 + noise_val;
+            let b = pixel[2] as f32 + noise_val;
+
+            pixel[0] = clamp_u8(r);
+            pixel[1] = clamp_u8(g);
+            pixel[2] = clamp_u8(b);
+        }
+    }
+}


### PR DESCRIPTION
- Implement [process_frame](cci:1://file:///home/jome/dev/chroma-lab/quickfix-renderer/src/lib.rs:51:0-61:1) entrypoint accepting JSON adjustments via `JsValue`.
- Define [QuickFixAdjustments](cci:2://file:///home/jome/dev/chroma-lab/quickfix-renderer/src/lib.rs:37:0-43:1) and related settings structs mirroring Python schemas.
- Implement deterministic image operations:
  - Geometry (bilinear coordinate mapping).
  - Crop/Rotate (bicubic resampling).
  - Exposure (contrast, highlights, shadows).
  - Color (temperature, tint).
  - Grain (seeded Gaussian noise).
- Add `image`, `rand`, `rand_chacha`, `rand_distr`, `serde-wasm-bindgen` dependencies.
- Add unit tests for serialization, deterministic grain, and pipeline execution. 