### PR TITLE
feat: add targeted HSL adjustments for 8 color ranges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ docs/tasks/refactor_geometric_ops.md
 # Generated Docs
 docs/ts/
 
+.VSCodeCounter/*

--- a/examples/minimal-viewer/src/App.test.tsx
+++ b/examples/minimal-viewer/src/App.test.tsx
@@ -68,11 +68,10 @@ describe('App Integration', () => {
             stroke: vi.fn(),
         } as unknown as CanvasRenderingContext2D;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(((contextId: string) => {
             if (contextId === '2d') return mockContext;
             return null;
-        }) as any);
+        }) as unknown as (contextId: string) => CanvasRenderingContext2D | null);
 
         // Mock Image
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -91,12 +90,19 @@ describe('App Integration', () => {
         // Mock ImageData
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (globalThis as any).ImageData = class {
-            constructor(public data: Uint8ClampedArray, public width: number, public height: number) { }
+            data: Uint8ClampedArray;
+            width: number;
+            height: number;
+            constructor(data: Uint8ClampedArray, width: number, height: number) {
+                this.data = data;
+                this.width = width;
+                this.height = height;
+            }
         };
 
         // Mock createImageBitmap
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (globalThis as any).createImageBitmap = async (_image: any) => {
+        (globalThis as any).createImageBitmap = async () => {
             return {
                 close: () => { },
                 width: 100,

--- a/examples/minimal-viewer/src/App.tsx
+++ b/examples/minimal-viewer/src/App.tsx
@@ -102,6 +102,13 @@ function App() {
   // Interaction State
   const [isPickingWB, setIsPickingWB] = useState(false);
 
+  // Split Toning
+  const [stShadowHue, setStShadowHue] = useState(210); // Default Teal-ish
+  const [stShadowSat, setStShadowSat] = useState(0);
+  const [stHighlightHue, setStHighlightHue] = useState(30); // Default Orange-ish
+  const [stHighlightSat, setStHighlightSat] = useState(0);
+  const [stBalance, setStBalance] = useState(0);
+
   const handleLutUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files || e.target.files.length === 0) return;
     const file = e.target.files[0];
@@ -337,7 +344,14 @@ function App() {
           flipHorizontal: flipHorizontal
         },
         curves: curves,
-        hsl: hsl
+        hsl: hsl,
+        splitToning: {
+          shadowHue: stShadowHue,
+          shadowSat: stShadowSat,
+          highlightHue: stHighlightHue,
+          highlightSat: stHighlightSat,
+          balance: stBalance
+        }
       };
 
       try {
@@ -438,7 +452,7 @@ function App() {
 
     render();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [imageData, image, exposure, contrast, highlights, shadows, temp, tint, grainAmount, grainSize, rotation, appliedCrop, cropX, cropY, cropW, cropH, geoVertical, geoHorizontal, flipVertical, flipHorizontal, currentBackend, lutIntensity, denoiseLuminance, denoiseColor, curves, hsl]);
+  }, [imageData, image, exposure, contrast, highlights, shadows, temp, tint, grainAmount, grainSize, rotation, appliedCrop, cropX, cropY, cropW, cropH, geoVertical, geoHorizontal, flipVertical, flipHorizontal, currentBackend, lutIntensity, denoiseLuminance, denoiseColor, curves, hsl, stShadowHue, stShadowSat, stHighlightHue, stHighlightSat, stBalance]);
 
   // Handle Canvas Click for WB Picking
   const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -645,6 +659,61 @@ function App() {
                   <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{tint.toFixed(2)}</span>
                 </div>
                 <input data-testid="tint-slider" type="range" min="-1" max="1" step="0.05" value={tint} onChange={e => setTint(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Split Toning</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '0.5rem', color: '#ccc' }}>Highlights</label>
+                <div style={{ marginBottom: '0.5rem' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                    <label style={{ fontSize: '0.85rem' }}>Hue</label>
+                    <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stHighlightHue}°</span>
+                  </div>
+                  <input type="range" min="0" max="360" step="1" value={stHighlightHue} onChange={e => setStHighlightHue(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                  <div style={{ height: '4px', background: `hsl(${stHighlightHue}, 100%, 50%)`, borderRadius: '2px', marginTop: '4px' }}></div>
+                </div>
+                <div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                    <label style={{ fontSize: '0.85rem' }}>Saturation</label>
+                    <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stHighlightSat}</span>
+                  </div>
+                  <input type="range" min="0" max="1" step="0.05" value={stHighlightSat} onChange={e => setStHighlightSat(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                </div>
+              </div>
+
+              <div>
+                <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '0.5rem', color: '#ccc' }}>Shadows</label>
+                <div style={{ marginBottom: '0.5rem' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                    <label style={{ fontSize: '0.85rem' }}>Hue</label>
+                    <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stShadowHue}°</span>
+                  </div>
+                  <input type="range" min="0" max="360" step="1" value={stShadowHue} onChange={e => setStShadowHue(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                  <div style={{ height: '4px', background: `hsl(${stShadowHue}, 100%, 50%)`, borderRadius: '2px', marginTop: '4px' }}></div>
+                </div>
+                <div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                    <label style={{ fontSize: '0.85rem' }}>Saturation</label>
+                    <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stShadowSat}</span>
+                  </div>
+                  <input type="range" min="0" max="1" step="0.05" value={stShadowSat} onChange={e => setStShadowSat(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                </div>
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Balance</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stBalance}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.1" value={stBalance} onChange={e => setStBalance(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.7rem', opacity: 0.5, marginTop: '2px' }}>
+                  <span>Shadows</span>
+                  <span>Highlights</span>
+                </div>
               </div>
             </div>
           </section>

--- a/examples/minimal-viewer/src/App.tsx
+++ b/examples/minimal-viewer/src/App.tsx
@@ -107,7 +107,14 @@ function App() {
   const [stShadowSat, setStShadowSat] = useState(0);
   const [stHighlightHue, setStHighlightHue] = useState(30); // Default Orange-ish
   const [stHighlightSat, setStHighlightSat] = useState(0);
+
   const [stBalance, setStBalance] = useState(0);
+
+  // Vignette
+  const [vAmount, setVAmount] = useState(0);
+  const [vMidpoint, setVMidpoint] = useState(0.5);
+  const [vRoundness, setVRoundness] = useState(0);
+  const [vFeather, setVFeather] = useState(0.5);
 
   const handleLutUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files || e.target.files.length === 0) return;
@@ -351,6 +358,12 @@ function App() {
           highlightHue: stHighlightHue,
           highlightSat: stHighlightSat,
           balance: stBalance
+        },
+        vignette: {
+          amount: vAmount,
+          midpoint: vMidpoint,
+          roundness: vRoundness,
+          feather: vFeather
         }
       };
 
@@ -452,7 +465,7 @@ function App() {
 
     render();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [imageData, image, exposure, contrast, highlights, shadows, temp, tint, grainAmount, grainSize, rotation, appliedCrop, cropX, cropY, cropW, cropH, geoVertical, geoHorizontal, flipVertical, flipHorizontal, currentBackend, lutIntensity, denoiseLuminance, denoiseColor, curves, hsl, stShadowHue, stShadowSat, stHighlightHue, stHighlightSat, stBalance]);
+  }, [imageData, image, exposure, contrast, highlights, shadows, temp, tint, grainAmount, grainSize, rotation, appliedCrop, cropX, cropY, cropW, cropH, geoVertical, geoHorizontal, flipVertical, flipHorizontal, currentBackend, lutIntensity, denoiseLuminance, denoiseColor, curves, hsl, stShadowHue, stShadowSat, stHighlightHue, stHighlightSat, stBalance, vAmount, vMidpoint, vRoundness, vFeather]);
 
   // Handle Canvas Click for WB Picking
   const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -767,6 +780,43 @@ function App() {
                   </div>
                 </div>
               ))}
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Vignette</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Amount</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vAmount}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.05" value={vAmount} onChange={e => setVAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Midpoint</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vMidpoint}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={vMidpoint} onChange={e => setVMidpoint(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Roundness</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vRoundness}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.05" value={vRoundness} onChange={e => setVRoundness(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Feather</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vFeather}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={vFeather} onChange={e => setVFeather(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
             </div>
           </section>
 

--- a/examples/minimal-viewer/src/App.tsx
+++ b/examples/minimal-viewer/src/App.tsx
@@ -134,9 +134,36 @@ function App() {
   const [flipVertical, setFlipVertical] = useState(false);
   const [flipHorizontal, setFlipHorizontal] = useState(false);
 
-  // Curves State
   const [curves, setCurves] = useState<CurvesSettings>({
     intensity: 1.0,
+  });
+
+  interface HslRange {
+    hue: number;
+    saturation: number;
+    luminance: number;
+  }
+
+  interface HslSettings {
+    red: HslRange;
+    orange: HslRange;
+    yellow: HslRange;
+    green: HslRange;
+    aqua: HslRange;
+    blue: HslRange;
+    purple: HslRange;
+    magenta: HslRange;
+  }
+
+  const [hsl, setHsl] = useState<HslSettings>({
+    red: { hue: 0, saturation: 0, luminance: 0 },
+    orange: { hue: 0, saturation: 0, luminance: 0 },
+    yellow: { hue: 0, saturation: 0, luminance: 0 },
+    green: { hue: 0, saturation: 0, luminance: 0 },
+    aqua: { hue: 0, saturation: 0, luminance: 0 },
+    blue: { hue: 0, saturation: 0, luminance: 0 },
+    purple: { hue: 0, saturation: 0, luminance: 0 },
+    magenta: { hue: 0, saturation: 0, luminance: 0 },
   });
 
   const setCurvesIntensity = (intensity: number) => {
@@ -309,7 +336,8 @@ function App() {
           flipVertical: flipVertical,
           flipHorizontal: flipHorizontal
         },
-        curves: curves
+        curves: curves,
+        hsl: hsl
       };
 
       try {
@@ -410,7 +438,7 @@ function App() {
 
     render();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [imageData, image, exposure, contrast, highlights, shadows, temp, tint, grainAmount, grainSize, rotation, appliedCrop, cropX, cropY, cropW, cropH, geoVertical, geoHorizontal, flipVertical, flipHorizontal, currentBackend, lutIntensity, denoiseLuminance, denoiseColor, curves]);
+  }, [imageData, image, exposure, contrast, highlights, shadows, temp, tint, grainAmount, grainSize, rotation, appliedCrop, cropX, cropY, cropW, cropH, geoVertical, geoHorizontal, flipVertical, flipHorizontal, currentBackend, lutIntensity, denoiseLuminance, denoiseColor, curves, hsl]);
 
   // Handle Canvas Click for WB Picking
   const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -618,6 +646,58 @@ function App() {
                 </div>
                 <input data-testid="tint-slider" type="range" min="-1" max="1" step="0.05" value={tint} onChange={e => setTint(parseFloat(e.target.value))} style={{ width: '100%' }} />
               </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>HSL Tuning</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+              {(['red', 'orange', 'yellow', 'green', 'aqua', 'blue', 'purple', 'magenta'] as const).map((col) => (
+                <div key={col} style={{ background: '#1a1a1a', padding: '0.8rem', borderRadius: '4px' }}>
+                  <div style={{ fontSize: '0.9rem', marginBottom: '0.6rem', color: '#fff', fontWeight: 'bold', textTransform: 'capitalize', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                    <div style={{ width: '12px', height: '12px', borderRadius: '50%', background: col }} />
+                    {col}
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                    <div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', opacity: 0.7 }}>
+                        <label>Hue</label>
+                        <span>{hsl[col].hue.toFixed(2)}</span>
+                      </div>
+                      <input
+                        type="range" min="-1" max="1" step="0.1"
+                        value={hsl[col].hue}
+                        onChange={e => setHsl({ ...hsl, [col]: { ...hsl[col], hue: parseFloat(e.target.value) } })}
+                        style={{ width: '100%' }}
+                      />
+                    </div>
+                    <div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', opacity: 0.7 }}>
+                        <label>Sat</label>
+                        <span>{hsl[col].saturation.toFixed(2)}</span>
+                      </div>
+                      <input
+                        type="range" min="-1" max="1" step="0.1"
+                        value={hsl[col].saturation}
+                        onChange={e => setHsl({ ...hsl, [col]: { ...hsl[col], saturation: parseFloat(e.target.value) } })}
+                        style={{ width: '100%' }}
+                      />
+                    </div>
+                    <div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', opacity: 0.7 }}>
+                        <label>Lum</label>
+                        <span>{hsl[col].luminance.toFixed(2)}</span>
+                      </div>
+                      <input
+                        type="range" min="-1" max="1" step="0.1"
+                        value={hsl[col].luminance}
+                        onChange={e => setHsl({ ...hsl, [col]: { ...hsl[col], luminance: parseFloat(e.target.value) } })}
+                        style={{ width: '100%' }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
             </div>
           </section>
 

--- a/examples/minimal-viewer/src/App.tsx
+++ b/examples/minimal-viewer/src/App.tsx
@@ -114,7 +114,17 @@ function App() {
   const [vAmount, setVAmount] = useState(0);
   const [vMidpoint, setVMidpoint] = useState(0.5);
   const [vRoundness, setVRoundness] = useState(0);
+
   const [vFeather, setVFeather] = useState(0.5);
+
+  // Sharpen / Clarity / Dehaze
+  const [sharpenAmount, setSharpenAmount] = useState(0);
+  const [sharpenRadius, setSharpenRadius] = useState(1.0);
+  const [sharpenThreshold, setSharpenThreshold] = useState(0);
+
+  const [clarityAmount, setClarityAmount] = useState(0);
+  const [dehazeAmount, setDehazeAmount] = useState(0);
+
 
   const handleLutUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target.files || e.target.files.length === 0) return;
@@ -364,6 +374,17 @@ function App() {
           midpoint: vMidpoint,
           roundness: vRoundness,
           feather: vFeather
+        },
+        sharpen: {
+          amount: sharpenAmount,
+          radius: sharpenRadius,
+          threshold: sharpenThreshold
+        },
+        clarity: {
+          amount: clarityAmount
+        },
+        dehaze: {
+          amount: dehazeAmount
         }
       };
 
@@ -465,7 +486,7 @@ function App() {
 
     render();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [imageData, image, exposure, contrast, highlights, shadows, temp, tint, grainAmount, grainSize, rotation, appliedCrop, cropX, cropY, cropW, cropH, geoVertical, geoHorizontal, flipVertical, flipHorizontal, currentBackend, lutIntensity, denoiseLuminance, denoiseColor, curves, hsl, stShadowHue, stShadowSat, stHighlightHue, stHighlightSat, stBalance, vAmount, vMidpoint, vRoundness, vFeather]);
+  }, [imageData, image, exposure, contrast, highlights, shadows, temp, tint, grainAmount, grainSize, rotation, appliedCrop, cropX, cropY, cropW, cropH, geoVertical, geoHorizontal, flipVertical, flipHorizontal, currentBackend, lutIntensity, denoiseLuminance, denoiseColor, curves, hsl, stShadowHue, stShadowSat, stHighlightHue, stHighlightSat, stBalance, vAmount, vMidpoint, vRoundness, vFeather, sharpenAmount, sharpenRadius, sharpenThreshold, clarityAmount, dehazeAmount]);
 
   // Handle Canvas Click for WB Picking
   const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
@@ -780,6 +801,56 @@ function App() {
                   </div>
                 </div>
               ))}
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Details</h3>
+
+            <div style={{ paddingBottom: '1rem', borderBottom: '1px solid #222', marginBottom: '1rem' }}>
+              <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '0.5rem', color: '#ccc' }}>Sharpen</label>
+
+              <div style={{ marginBottom: '0.8rem' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Amount</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{sharpenAmount}</span>
+                </div>
+                <input type="range" min="0" max="5.0" step="0.1" value={sharpenAmount} onChange={e => setSharpenAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div style={{ marginBottom: '0.8rem' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Radius</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{sharpenRadius}</span>
+                </div>
+                <input type="range" min="0.1" max="10.0" step="0.1" value={sharpenRadius} onChange={e => setSharpenRadius(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Threshold</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{sharpenThreshold}</span>
+                </div>
+                <input type="range" min="0" max="50" step="1" value={sharpenThreshold} onChange={e => setSharpenThreshold(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Clarity</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{clarityAmount}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.05" value={clarityAmount} onChange={e => setClarityAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Dehaze</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{dehazeAmount}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={dehazeAmount} onChange={e => setDehazeAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
             </div>
           </section>
 

--- a/examples/minimal-viewer/src/App.tsx
+++ b/examples/minimal-viewer/src/App.tsx
@@ -389,704 +389,706 @@ function App() {
         },
         dehaze: {
           amount: dehazeAmount
-        };
+        }, // End dehaze
+        // End settings properties
+      };
 
-        try {
-          // Explicitly resize canvas
-          if(canvasRef.current!.width !== image.width || canvasRef.current!.height !== image.height) {
-    canvasRef.current!.width = image.width;
-    canvasRef.current!.height = image.height;
-  }
-
-  console.log("App: Rendering with settings:", JSON.stringify(settings, null, 2));
-
-  // Stateful render: Pass null for imageData
-  const res = await clientRef.current!.render(
-    null,
-    image.width,
-    image.height,
-    settings
-  );
-
-  const { imageBitmap, width, height, histogram } = res;
-  if (histogram) {
-    setHistogramData(histogram);
-  }
-
-  const ctx = canvasRef.current!.getContext('2d');
-  if (ctx) {
-    // 1. Put the rendered image (Cropped or Full)
-    const buf = imageBitmap as ArrayBuffer;
-    const clamped = new Uint8ClampedArray(buf);
-    const imgData = new ImageData(clamped, width, height);
-
-    if (appliedCrop) {
-      // CROP MODE: Draw only the selected region
-      const cropX = Math.round(appliedCrop.x * width);
-      const cropY = Math.round(appliedCrop.y * height);
-      const cropW = Math.round(appliedCrop.width * width);
-      const cropH = Math.round(appliedCrop.height * height);
-
-      // Clamp bounds
-      const safeX = Math.max(0, cropX);
-      const safeY = Math.max(0, cropY);
-      // Ensure width/height don't exceed image bounds
-      const safeW = Math.min(width - safeX, cropW);
-      const safeH = Math.min(height - safeY, cropH);
-
-      if (safeW > 0 && safeH > 0) {
-        // Resize canvas to CROP dimensions
-        if (canvasRef.current!.width !== safeW || canvasRef.current!.height !== safeH) {
-          canvasRef.current!.width = safeW;
-          canvasRef.current!.height = safeH;
+      try {
+        // Explicitly resize canvas
+        if (canvasRef.current!.width !== image.width || canvasRef.current!.height !== image.height) {
+          canvasRef.current!.width = image.width;
+          canvasRef.current!.height = image.height;
         }
 
-        // Create cropped bitmap
-        createImageBitmap(imgData, safeX, safeY, safeW, safeH).then(bitmap => {
-          ctx.drawImage(bitmap, 0, 0);
-          bitmap.close();
-        }).catch(err => {
-          console.error("Failed to create crop bitmap:", err);
-        });
+        console.log("App: Rendering with settings:", JSON.stringify(settings, null, 2));
+
+        // Stateful render: Pass null for imageData
+        const res = await clientRef.current!.render(
+          null,
+          image.width,
+          image.height,
+          settings
+        );
+
+        const { imageBitmap, width, height, histogram } = res;
+        if (histogram) {
+          setHistogramData(histogram);
+        }
+
+        const ctx = canvasRef.current!.getContext('2d');
+        if (ctx) {
+          // 1. Put the rendered image (Cropped or Full)
+          const buf = imageBitmap as ArrayBuffer;
+          const clamped = new Uint8ClampedArray(buf);
+          const imgData = new ImageData(clamped, width, height);
+
+          if (appliedCrop) {
+            // CROP MODE: Draw only the selected region
+            const cropX = Math.round(appliedCrop.x * width);
+            const cropY = Math.round(appliedCrop.y * height);
+            const cropW = Math.round(appliedCrop.width * width);
+            const cropH = Math.round(appliedCrop.height * height);
+
+            // Clamp bounds
+            const safeX = Math.max(0, cropX);
+            const safeY = Math.max(0, cropY);
+            // Ensure width/height don't exceed image bounds
+            const safeW = Math.min(width - safeX, cropW);
+            const safeH = Math.min(height - safeY, cropH);
+
+            if (safeW > 0 && safeH > 0) {
+              // Resize canvas to CROP dimensions
+              if (canvasRef.current!.width !== safeW || canvasRef.current!.height !== safeH) {
+                canvasRef.current!.width = safeW;
+                canvasRef.current!.height = safeH;
+              }
+
+              // Create cropped bitmap
+              createImageBitmap(imgData, safeX, safeY, safeW, safeH).then(bitmap => {
+                ctx.drawImage(bitmap, 0, 0);
+                bitmap.close();
+              }).catch(err => {
+                console.error("Failed to create crop bitmap:", err);
+              });
+            }
+
+          } else {
+            // FULL MODE: Draw full image + Overlay
+            if (canvasRef.current!.width !== width || canvasRef.current!.height !== height) {
+              canvasRef.current!.width = width;
+              canvasRef.current!.height = height;
+            }
+            ctx.putImageData(imgData, 0, 0);
+
+            // Overlay on top
+            const x = Math.round(cropX * width);
+            const y = Math.round(cropY * height);
+            const w = Math.round(cropW * width);
+            const h = Math.round(cropH * height);
+
+            ctx.strokeStyle = 'red';
+            ctx.lineWidth = 2;
+            ctx.strokeRect(x, y, w, h);
+
+            // Semi-transparent fill outside
+            ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+            // Top
+            ctx.fillRect(0, 0, width, y);
+            // Bottom
+            ctx.fillRect(0, y + h, width, height - (y + h));
+            // Left
+            ctx.fillRect(0, y, x, h);
+            // Right
+            ctx.fillRect(x + w, y, width - (x + w), h);
+          }
+        }
+      } catch (e) {
+        console.error("Render failed:", e);
+      } finally {
+        setIsRendering(false);
       }
-
-    } else {
-      // FULL MODE: Draw full image + Overlay
-      if (canvasRef.current!.width !== width || canvasRef.current!.height !== height) {
-        canvasRef.current!.width = width;
-        canvasRef.current!.height = height;
-      }
-      ctx.putImageData(imgData, 0, 0);
-
-      // Overlay on top
-      const x = Math.round(cropX * width);
-      const y = Math.round(cropY * height);
-      const w = Math.round(cropW * width);
-      const h = Math.round(cropH * height);
-
-      ctx.strokeStyle = 'red';
-      ctx.lineWidth = 2;
-      ctx.strokeRect(x, y, w, h);
-
-      // Semi-transparent fill outside
-      ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
-      // Top
-      ctx.fillRect(0, 0, width, y);
-      // Bottom
-      ctx.fillRect(0, y + h, width, height - (y + h));
-      // Left
-      ctx.fillRect(0, y, x, h);
-      // Right
-      ctx.fillRect(x + w, y, width - (x + w), h);
-    }
-  }
-} catch (e) {
-  console.error("Render failed:", e);
-} finally {
-  setIsRendering(false);
-}
     };
 
-render();
+    render();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [imageData, image, exposure, contrast, highlights, shadows, temp, tint, grainAmount, grainSize, rotation, appliedCrop, cropX, cropY, cropW, cropH, geoVertical, geoHorizontal, flipVertical, flipHorizontal, distK1, distK2, currentBackend, lutIntensity, denoiseLuminance, denoiseColor, curves, hsl, stShadowHue, stShadowSat, stHighlightHue, stHighlightSat, stBalance, vAmount, vMidpoint, vRoundness, vFeather, sharpenAmount, sharpenRadius, sharpenThreshold, clarityAmount, dehazeAmount]);
 
-// Handle Canvas Click for WB Picking
-const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
-  // Guard: Basic checks
-  if (!isPickingWB || !imageData || !image || !canvasRef.current) return;
+  // Handle Canvas Click for WB Picking
+  const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    // Guard: Basic checks
+    if (!isPickingWB || !imageData || !image || !canvasRef.current) return;
 
-  // Guard: Geometry must be neutral (Rotation/Perspective makes mapping complex)
-  if (Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0 || Math.abs(distK1) > 0 || Math.abs(distK2) > 0) {
-    console.warn("WB Picker: Cannot pick with active geometry/distortion transforms.");
-    setIsPickingWB(false);
-    return;
-  }
+    // Guard: Geometry must be neutral (Rotation/Perspective makes mapping complex)
+    if (Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0 || Math.abs(distK1) > 0 || Math.abs(distK2) > 0) {
+      console.warn("WB Picker: Cannot pick with active geometry/distortion transforms.");
+      setIsPickingWB(false);
+      return;
+    }
 
-  const rect = canvasRef.current.getBoundingClientRect();
-  const x = e.clientX - rect.left;
-  const y = e.clientY - rect.top;
+    const rect = canvasRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
 
-  // Map screen coordinates to canvas internal resolution
-  const scaleX = canvasRef.current.width / rect.width;
-  const scaleY = canvasRef.current.height / rect.height;
+    // Map screen coordinates to canvas internal resolution
+    const scaleX = canvasRef.current.width / rect.width;
+    const scaleY = canvasRef.current.height / rect.height;
 
-  const canvasX = Math.floor(x * scaleX);
-  const canvasY = Math.floor(y * scaleY);
+    const canvasX = Math.floor(x * scaleX);
+    const canvasY = Math.floor(y * scaleY);
 
-  let imgX = canvasX;
-  let imgY = canvasY;
+    let imgX = canvasX;
+    let imgY = canvasY;
 
-  if (appliedCrop) {
-    // If cropped, map canvas coordinates back to original image coordinates
-    // See render loop logic: safeX, safeY were used to crop existing image
-    const width = image.width;
-    const height = image.height;
-    const cropX = Math.round(appliedCrop.x * width);
-    const cropY = Math.round(appliedCrop.y * height);
+    if (appliedCrop) {
+      // If cropped, map canvas coordinates back to original image coordinates
+      // See render loop logic: safeX, safeY were used to crop existing image
+      const width = image.width;
+      const height = image.height;
+      const cropX = Math.round(appliedCrop.x * width);
+      const cropY = Math.round(appliedCrop.y * height);
 
-    const safeX = Math.max(0, cropX);
-    const safeY = Math.max(0, cropY);
+      const safeX = Math.max(0, cropX);
+      const safeY = Math.max(0, cropY);
 
-    imgX = safeX + canvasX;
-    imgY = safeY + canvasY;
-  }
+      imgX = safeX + canvasX;
+      imgY = safeY + canvasY;
+    }
 
-  // Boundary check
-  if (imgX < 0 || imgX >= image.width || imgY < 0 || imgY >= image.height) {
-    return;
-  }
+    // Boundary check
+    if (imgX < 0 || imgX >= image.width || imgY < 0 || imgY >= image.height) {
+      return;
+    }
 
-  // Handle Flips (Map visual coordinate to source coordinate)
-  // If displayed image is flipped, the pixel at 'imgX' corresponds to 'width - imgX' in source
-  if (flipHorizontal) {
-    // Logic: If appliedCrop is active, the crop rect itself was flipped? 
-    // Current pipeline: Flips happen LAST in shader (closest to resource)?
-    // No, usually flips are applied to the whole image.
-    // If we are in Crop mode, we are seeing a crop of the flipped image?
-    // Let's assume Flip is applied to the WHOLE image space.
-    // So Source(x) = Width - 1 - Display(x).
-    // If Cropped: We have mapped Display(x) -> ImageSpace(x) via safeX offset.
-    // Now invert the global flip.
-    imgX = image.width - 1 - imgX;
-  }
-  if (flipVertical) {
-    imgY = image.height - 1 - imgY;
-  }
+    // Handle Flips (Map visual coordinate to source coordinate)
+    // If displayed image is flipped, the pixel at 'imgX' corresponds to 'width - imgX' in source
+    if (flipHorizontal) {
+      // Logic: If appliedCrop is active, the crop rect itself was flipped? 
+      // Current pipeline: Flips happen LAST in shader (closest to resource)?
+      // No, usually flips are applied to the whole image.
+      // If we are in Crop mode, we are seeing a crop of the flipped image?
+      // Let's assume Flip is applied to the WHOLE image space.
+      // So Source(x) = Width - 1 - Display(x).
+      // If Cropped: We have mapped Display(x) -> ImageSpace(x) via safeX offset.
+      // Now invert the global flip.
+      imgX = image.width - 1 - imgX;
+    }
+    if (flipVertical) {
+      imgY = image.height - 1 - imgY;
+    }
 
-  // Sample from ORIGINAL image data
-  const idx = (imgY * image.width + imgX) * 4;
-  const r = imageData[idx];
-  const g = imageData[idx + 1];
-  const b = imageData[idx + 2];
+    // Sample from ORIGINAL image data
+    const idx = (imgY * image.width + imgX) * 4;
+    const r = imageData[idx];
+    const g = imageData[idx + 1];
+    const b = imageData[idx + 2];
 
-  console.log(`WB Pick at (${imgX}, ${imgY}): R=${r}, G=${g}, B=${b}`);
+    console.log(`WB Pick at (${imgX}, ${imgY}): R=${r}, G=${g}, B=${b}`);
 
-  const res = calculateWhiteBalance(r, g, b);
-  console.log("Calculated WB:", res);
+    const res = calculateWhiteBalance(r, g, b);
+    console.log("Calculated WB:", res);
 
-  setTemp(res.temp);
-  setTint(res.tint);
-  setIsPickingWB(false); // Disable picker after selection
-};
+    setTemp(res.temp);
+    setTint(res.tint);
+    setIsPickingWB(false); // Disable picker after selection
+  };
 
-return (
-  <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden', background: '#111', color: '#eee', fontFamily: 'Inter, system-ui, sans-serif' }}>
-    <header style={{ padding: '0.5rem 1rem', borderBottom: '1px solid #333', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-      <h1 style={{ margin: 0, fontSize: '1.2rem' }}>Quick Fix GPU Renderer</h1>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-        <div>
-          <label style={{ fontSize: '0.8rem', opacity: 0.7 }}>Backend: </label>
-          <select
-            value={backend}
-            onChange={(e) => setBackend(e.target.value)}
-            style={{ background: '#222', color: '#eee', border: '1px solid #444', borderRadius: '4px', fontSize: '0.8rem' }}
-          >
-            <option value="auto">Auto</option>
-            <option value="webgpu">WebGPU</option>
-            <option value="webgl2">WebGL2</option>
-            <option value="cpu">CPU</option>
-          </select>
-        </div>
-        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '0.2rem' }}>
-          <span style={{ fontSize: '0.8rem', opacity: 0.7 }}>Current: {currentBackend}</span>
-          <span style={{ fontSize: '0.8rem', opacity: 0.7 }}>Image Size: {image?.width}x{image?.height}</span>
-        </div>
-      </div>
-    </header>
-
-    <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
-      <main style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '2rem', overflow: 'auto', background: '#000' }}>
-        <canvas
-          ref={canvasRef}
-          key={backend}
-          onClick={handleCanvasClick}
-          style={{
-            border: '1px solid #333',
-            maxWidth: '100%',
-            maxHeight: '100%',
-            objectFit: 'contain',
-            display: 'block',
-            cursor: isPickingWB ? 'crosshair' : 'default',
-            boxShadow: '0 10px 30px rgba(0,0,0,0.5)'
-          }}
-        />
-      </main>
-
-      <aside aria-label="Sidebar controls" style={{
-        width: '350px',
-        borderLeft: '1px solid #333',
-        overflowY: 'auto',
-        padding: '1.5rem',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '1.5rem',
-        background: '#111'
-      }}>
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Exposure</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Exposure</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{exposure}</span>
-              </div>
-              <input type="range" min="-2" max="2" step="0.1" value={exposure} onChange={e => setExposure(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Contrast</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{contrast}</span>
-              </div>
-              <input type="range" min="0.5" max="1.5" step="0.05" value={contrast} onChange={e => setContrast(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Highlights</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{highlights}</span>
-              </div>
-              <input type="range" min="-1" max="1" step="0.1" value={highlights} onChange={e => setHighlights(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Shadows</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{shadows}</span>
-              </div>
-              <input type="range" min="-1" max="1" step="0.1" value={shadows} onChange={e => setShadows(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-          </div>
-        </section>
-
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Color</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <button
-              onClick={() => setIsPickingWB(!isPickingWB)}
-              disabled={Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0}
-              title={Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0 ? "Reset Geometry/Rotation to pick WB" : "Click image to set White Balance"}
-              style={{
-                background: isPickingWB ? '#444' : '#222',
-                color: '#eee',
-                border: '1px solid #444',
-                padding: '6px 12px',
-                borderRadius: '4px',
-                cursor: (Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0) ? 'not-allowed' : 'pointer',
-                fontSize: '0.8rem',
-                width: '100%',
-                opacity: (Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0) ? 0.5 : 1
-              }}
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden', background: '#111', color: '#eee', fontFamily: 'Inter, system-ui, sans-serif' }}>
+      <header style={{ padding: '0.5rem 1rem', borderBottom: '1px solid #333', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <h1 style={{ margin: 0, fontSize: '1.2rem' }}>Quick Fix GPU Renderer</h1>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+          <div>
+            <label style={{ fontSize: '0.8rem', opacity: 0.7 }}>Backend: </label>
+            <select
+              value={backend}
+              onChange={(e) => setBackend(e.target.value)}
+              style={{ background: '#222', color: '#eee', border: '1px solid #444', borderRadius: '4px', fontSize: '0.8rem' }}
             >
-              {isPickingWB ? 'Cancel Picker' : 'Pick Neutral Gray'}
-            </button>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Temp</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{temp.toFixed(2)}</span>
-              </div>
-              <input data-testid="temp-slider" type="range" min="-1" max="1" step="0.05" value={temp} onChange={e => setTemp(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Tint</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{tint.toFixed(2)}</span>
-              </div>
-              <input data-testid="tint-slider" type="range" min="-1" max="1" step="0.05" value={tint} onChange={e => setTint(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
+              <option value="auto">Auto</option>
+              <option value="webgpu">WebGPU</option>
+              <option value="webgl2">WebGL2</option>
+              <option value="cpu">CPU</option>
+            </select>
           </div>
-        </section>
+          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: '0.2rem' }}>
+            <span style={{ fontSize: '0.8rem', opacity: 0.7 }}>Current: {currentBackend}</span>
+            <span style={{ fontSize: '0.8rem', opacity: 0.7 }}>Image Size: {image?.width}x{image?.height}</span>
+          </div>
+        </div>
+      </header>
 
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Split Toning</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div>
-              <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '0.5rem', color: '#ccc' }}>Highlights</label>
-              <div style={{ marginBottom: '0.5rem' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                  <label style={{ fontSize: '0.85rem' }}>Hue</label>
-                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stHighlightHue}°</span>
-                </div>
-                <input type="range" min="0" max="360" step="1" value={stHighlightHue} onChange={e => setStHighlightHue(parseFloat(e.target.value))} style={{ width: '100%' }} />
-                <div style={{ height: '4px', background: `hsl(${stHighlightHue}, 100%, 50%)`, borderRadius: '2px', marginTop: '4px' }}></div>
-              </div>
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        <main style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '2rem', overflow: 'auto', background: '#000' }}>
+          <canvas
+            ref={canvasRef}
+            key={backend}
+            onClick={handleCanvasClick}
+            style={{
+              border: '1px solid #333',
+              maxWidth: '100%',
+              maxHeight: '100%',
+              objectFit: 'contain',
+              display: 'block',
+              cursor: isPickingWB ? 'crosshair' : 'default',
+              boxShadow: '0 10px 30px rgba(0,0,0,0.5)'
+            }}
+          />
+        </main>
+
+        <aside aria-label="Sidebar controls" style={{
+          width: '350px',
+          borderLeft: '1px solid #333',
+          overflowY: 'auto',
+          padding: '1.5rem',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1.5rem',
+          background: '#111'
+        }}>
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Exposure</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
               <div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                  <label style={{ fontSize: '0.85rem' }}>Saturation</label>
-                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stHighlightSat}</span>
+                  <label style={{ fontSize: '0.85rem' }}>Exposure</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{exposure}</span>
                 </div>
-                <input type="range" min="0" max="1" step="0.05" value={stHighlightSat} onChange={e => setStHighlightSat(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                <input type="range" min="-2" max="2" step="0.1" value={exposure} onChange={e => setExposure(parseFloat(e.target.value))} style={{ width: '100%' }} />
               </div>
-            </div>
 
-            <div>
-              <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '0.5rem', color: '#ccc' }}>Shadows</label>
-              <div style={{ marginBottom: '0.5rem' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                  <label style={{ fontSize: '0.85rem' }}>Hue</label>
-                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stShadowHue}°</span>
-                </div>
-                <input type="range" min="0" max="360" step="1" value={stShadowHue} onChange={e => setStShadowHue(parseFloat(e.target.value))} style={{ width: '100%' }} />
-                <div style={{ height: '4px', background: `hsl(${stShadowHue}, 100%, 50%)`, borderRadius: '2px', marginTop: '4px' }}></div>
-              </div>
               <div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                  <label style={{ fontSize: '0.85rem' }}>Saturation</label>
-                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stShadowSat}</span>
+                  <label style={{ fontSize: '0.85rem' }}>Contrast</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{contrast}</span>
                 </div>
-                <input type="range" min="0" max="1" step="0.05" value={stShadowSat} onChange={e => setStShadowSat(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                <input type="range" min="0.5" max="1.5" step="0.05" value={contrast} onChange={e => setContrast(parseFloat(e.target.value))} style={{ width: '100%' }} />
               </div>
-            </div>
 
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Balance</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stBalance}</span>
-              </div>
-              <input type="range" min="-1" max="1" step="0.1" value={stBalance} onChange={e => setStBalance(parseFloat(e.target.value))} style={{ width: '100%' }} />
-              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.7rem', opacity: 0.5, marginTop: '2px' }}>
-                <span>Shadows</span>
-                <span>Highlights</span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Lens Distortion</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>k1 (Main)</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{distK1.toFixed(2)}</span>
-              </div>
-              <input type="range" min="-1" max="1" step="0.01" value={distK1} onChange={e => setDistK1(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>k2 (Secondary)</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{distK2.toFixed(2)}</span>
-              </div>
-              <input type="range" min="-1" max="1" step="0.01" value={distK2} onChange={e => setDistK2(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-          </div>
-        </section>
-
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>HSL Tuning</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-            {(['red', 'orange', 'yellow', 'green', 'aqua', 'blue', 'purple', 'magenta'] as const).map((col) => (
-              <div key={col} style={{ background: '#1a1a1a', padding: '0.8rem', borderRadius: '4px' }}>
-                <div style={{ fontSize: '0.9rem', marginBottom: '0.6rem', color: '#fff', fontWeight: 'bold', textTransform: 'capitalize', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
-                  <div style={{ width: '12px', height: '12px', borderRadius: '50%', background: col }} />
-                  {col}
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Highlights</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{highlights}</span>
                 </div>
-                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-                  <div>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', opacity: 0.7 }}>
-                      <label>Hue</label>
-                      <span>{hsl[col].hue.toFixed(2)}</span>
-                    </div>
-                    <input
-                      type="range" min="-1" max="1" step="0.1"
-                      value={hsl[col].hue}
-                      onChange={e => setHsl({ ...hsl, [col]: { ...hsl[col], hue: parseFloat(e.target.value) } })}
-                      style={{ width: '100%' }}
-                    />
-                  </div>
-                  <div>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', opacity: 0.7 }}>
-                      <label>Sat</label>
-                      <span>{hsl[col].saturation.toFixed(2)}</span>
-                    </div>
-                    <input
-                      type="range" min="-1" max="1" step="0.1"
-                      value={hsl[col].saturation}
-                      onChange={e => setHsl({ ...hsl, [col]: { ...hsl[col], saturation: parseFloat(e.target.value) } })}
-                      style={{ width: '100%' }}
-                    />
-                  </div>
-                  <div>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', opacity: 0.7 }}>
-                      <label>Lum</label>
-                      <span>{hsl[col].luminance.toFixed(2)}</span>
-                    </div>
-                    <input
-                      type="range" min="-1" max="1" step="0.1"
-                      value={hsl[col].luminance}
-                      onChange={e => setHsl({ ...hsl, [col]: { ...hsl[col], luminance: parseFloat(e.target.value) } })}
-                      style={{ width: '100%' }}
-                    />
-                  </div>
+                <input type="range" min="-1" max="1" step="0.1" value={highlights} onChange={e => setHighlights(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Shadows</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{shadows}</span>
                 </div>
+                <input type="range" min="-1" max="1" step="0.1" value={shadows} onChange={e => setShadows(parseFloat(e.target.value))} style={{ width: '100%' }} />
               </div>
-            ))}
-          </div>
-        </section>
-
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Details</h3>
-
-          <div style={{ paddingBottom: '1rem', borderBottom: '1px solid #222', marginBottom: '1rem' }}>
-            <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '0.5rem', color: '#ccc' }}>Sharpen</label>
-
-            <div style={{ marginBottom: '0.8rem' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Amount</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{sharpenAmount}</span>
-              </div>
-              <input type="range" min="0" max="5.0" step="0.1" value={sharpenAmount} onChange={e => setSharpenAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
             </div>
+          </section>
 
-            <div style={{ marginBottom: '0.8rem' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Radius</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{sharpenRadius}</span>
-              </div>
-              <input type="range" min="0.1" max="10.0" step="0.1" value={sharpenRadius} onChange={e => setSharpenRadius(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Threshold</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{sharpenThreshold}</span>
-              </div>
-              <input type="range" min="0" max="50" step="1" value={sharpenThreshold} onChange={e => setSharpenThreshold(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-          </div>
-
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Clarity</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{clarityAmount}</span>
-              </div>
-              <input type="range" min="-1" max="1" step="0.05" value={clarityAmount} onChange={e => setClarityAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Dehaze</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{dehazeAmount}</span>
-              </div>
-              <input type="range" min="0" max="1" step="0.05" value={dehazeAmount} onChange={e => setDehazeAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-          </div>
-        </section>
-
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Vignette</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Amount</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vAmount}</span>
-              </div>
-              <input type="range" min="-1" max="1" step="0.05" value={vAmount} onChange={e => setVAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Midpoint</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vMidpoint}</span>
-              </div>
-              <input type="range" min="0" max="1" step="0.05" value={vMidpoint} onChange={e => setVMidpoint(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Roundness</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vRoundness}</span>
-              </div>
-              <input type="range" min="-1" max="1" step="0.05" value={vRoundness} onChange={e => setVRoundness(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Feather</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vFeather}</span>
-              </div>
-              <input type="range" min="0" max="1" step="0.05" value={vFeather} onChange={e => setVFeather(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-          </div>
-        </section>
-
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Grain</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Amount</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{grainAmount}</span>
-              </div>
-              <input type="range" min="0" max="1" step="0.05" value={grainAmount} onChange={e => setGrainAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <label style={{ fontSize: '0.85rem', display: 'block', marginBottom: '0.3rem' }}>Size</label>
-              <select
-                value={grainSize}
-                onChange={e => setGrainSize(e.target.value as 'fine' | 'medium' | 'coarse')}
-                style={{ width: '100%', background: '#222', color: '#eee', border: '1px solid #444', padding: '4px', borderRadius: '4px' }}
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Color</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <button
+                onClick={() => setIsPickingWB(!isPickingWB)}
+                disabled={Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0}
+                title={Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0 ? "Reset Geometry/Rotation to pick WB" : "Click image to set White Balance"}
+                style={{
+                  background: isPickingWB ? '#444' : '#222',
+                  color: '#eee',
+                  border: '1px solid #444',
+                  padding: '6px 12px',
+                  borderRadius: '4px',
+                  cursor: (Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0) ? 'not-allowed' : 'pointer',
+                  fontSize: '0.8rem',
+                  width: '100%',
+                  opacity: (Math.abs(rotation) > 0 || Math.abs(geoVertical) > 0 || Math.abs(geoHorizontal) > 0) ? 0.5 : 1
+                }}
               >
-                <option value="fine">Fine</option>
-                <option value="medium">Medium</option>
-                <option value="coarse">Coarse</option>
-              </select>
-            </div>
-          </div>
-        </section>
+                {isPickingWB ? 'Cancel Picker' : 'Pick Neutral Gray'}
+              </button>
 
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Denoise</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Luminance</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{denoiseLuminance}</span>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Temp</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{temp.toFixed(2)}</span>
+                </div>
+                <input data-testid="temp-slider" type="range" min="-1" max="1" step="0.05" value={temp} onChange={e => setTemp(parseFloat(e.target.value))} style={{ width: '100%' }} />
               </div>
-              <input type="range" min="0" max="1" step="0.05" value={denoiseLuminance} onChange={e => setDenoiseLuminance(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
 
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Color</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{denoiseColor}</span>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Tint</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{tint.toFixed(2)}</span>
+                </div>
+                <input data-testid="tint-slider" type="range" min="-1" max="1" step="0.05" value={tint} onChange={e => setTint(parseFloat(e.target.value))} style={{ width: '100%' }} />
               </div>
-              <input type="range" min="0" max="1" step="0.05" value={denoiseColor} onChange={e => setDenoiseColor(parseFloat(e.target.value))} style={{ width: '100%' }} />
             </div>
-          </div>
-        </section>
+          </section>
 
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>LUT</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <input type="file" accept=".cube,.3dl,.xmp,.xml" onChange={handleLutUpload} style={{ fontSize: '0.8rem' }} />
-            {lutName && <span style={{ fontSize: '0.75rem', color: '#4caf50' }}>Loaded: {lutName}</span>}
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Intensity</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{lutIntensity}</span>
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Split Toning</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '0.5rem', color: '#ccc' }}>Highlights</label>
+                <div style={{ marginBottom: '0.5rem' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                    <label style={{ fontSize: '0.85rem' }}>Hue</label>
+                    <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stHighlightHue}°</span>
+                  </div>
+                  <input type="range" min="0" max="360" step="1" value={stHighlightHue} onChange={e => setStHighlightHue(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                  <div style={{ height: '4px', background: `hsl(${stHighlightHue}, 100%, 50%)`, borderRadius: '2px', marginTop: '4px' }}></div>
+                </div>
+                <div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                    <label style={{ fontSize: '0.85rem' }}>Saturation</label>
+                    <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stHighlightSat}</span>
+                  </div>
+                  <input type="range" min="0" max="1" step="0.05" value={stHighlightSat} onChange={e => setStHighlightSat(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                </div>
               </div>
-              <input type="range" min="0" max="1" step="0.05" value={lutIntensity} onChange={e => setLutIntensity(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-          </div>
-        </section>
 
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Curves</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Curve Strength</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{curves.intensity}</span>
+              <div>
+                <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '0.5rem', color: '#ccc' }}>Shadows</label>
+                <div style={{ marginBottom: '0.5rem' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                    <label style={{ fontSize: '0.85rem' }}>Hue</label>
+                    <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stShadowHue}°</span>
+                  </div>
+                  <input type="range" min="0" max="360" step="1" value={stShadowHue} onChange={e => setStShadowHue(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                  <div style={{ height: '4px', background: `hsl(${stShadowHue}, 100%, 50%)`, borderRadius: '2px', marginTop: '4px' }}></div>
+                </div>
+                <div>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                    <label style={{ fontSize: '0.85rem' }}>Saturation</label>
+                    <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stShadowSat}</span>
+                  </div>
+                  <input type="range" min="0" max="1" step="0.05" value={stShadowSat} onChange={e => setStShadowSat(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                </div>
               </div>
-              <input data-testid="curve-strength-slider" type="range" min="0" max="1" step="0.05" value={curves.intensity} onChange={e => setCurvesIntensity(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-            <CurveEditor curves={curves} onChange={setCurves} />
-          </div>
-        </section>
 
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Geometry</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Rotation</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{rotation}°</span>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Balance</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{stBalance}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.1" value={stBalance} onChange={e => setStBalance(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.7rem', opacity: 0.5, marginTop: '2px' }}>
+                  <span>Shadows</span>
+                  <span>Highlights</span>
+                </div>
               </div>
-              <input data-testid="rotation-slider" type="range" min="-45" max="45" step="1" value={rotation} onChange={e => setRotation(parseFloat(e.target.value))} style={{ width: '100%' }} />
             </div>
+          </section>
 
-            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.85rem' }}>
-              <input type="checkbox" checked={autoCrop} onChange={e => setAutoCrop(e.target.checked)} />
-              Auto Crop (Straighten)
-            </label>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Vertical Perspective</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{geoVertical}</span>
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Lens Distortion</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>k1 (Main)</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{distK1.toFixed(2)}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.01" value={distK1} onChange={e => setDistK1(parseFloat(e.target.value))} style={{ width: '100%' }} />
               </div>
-              <input type="range" min="-1" max="1" step="0.05" value={geoVertical} onChange={e => setGeoVertical(parseFloat(e.target.value))} style={{ width: '100%' }} />
-            </div>
-
-            <div>
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
-                <label style={{ fontSize: '0.85rem' }}>Horizontal Perspective</label>
-                <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{geoHorizontal}</span>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>k2 (Secondary)</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{distK2.toFixed(2)}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.01" value={distK2} onChange={e => setDistK2(parseFloat(e.target.value))} style={{ width: '100%' }} />
               </div>
-              <input type="range" min="-1" max="1" step="0.05" value={geoHorizontal} onChange={e => setGeoHorizontal(parseFloat(e.target.value))} style={{ width: '100%' }} />
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>HSL Tuning</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+              {(['red', 'orange', 'yellow', 'green', 'aqua', 'blue', 'purple', 'magenta'] as const).map((col) => (
+                <div key={col} style={{ background: '#1a1a1a', padding: '0.8rem', borderRadius: '4px' }}>
+                  <div style={{ fontSize: '0.9rem', marginBottom: '0.6rem', color: '#fff', fontWeight: 'bold', textTransform: 'capitalize', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                    <div style={{ width: '12px', height: '12px', borderRadius: '50%', background: col }} />
+                    {col}
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                    <div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', opacity: 0.7 }}>
+                        <label>Hue</label>
+                        <span>{hsl[col].hue.toFixed(2)}</span>
+                      </div>
+                      <input
+                        type="range" min="-1" max="1" step="0.1"
+                        value={hsl[col].hue}
+                        onChange={e => setHsl({ ...hsl, [col]: { ...hsl[col], hue: parseFloat(e.target.value) } })}
+                        style={{ width: '100%' }}
+                      />
+                    </div>
+                    <div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', opacity: 0.7 }}>
+                        <label>Sat</label>
+                        <span>{hsl[col].saturation.toFixed(2)}</span>
+                      </div>
+                      <input
+                        type="range" min="-1" max="1" step="0.1"
+                        value={hsl[col].saturation}
+                        onChange={e => setHsl({ ...hsl, [col]: { ...hsl[col], saturation: parseFloat(e.target.value) } })}
+                        style={{ width: '100%' }}
+                      />
+                    </div>
+                    <div>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '0.75rem', opacity: 0.7 }}>
+                        <label>Lum</label>
+                        <span>{hsl[col].luminance.toFixed(2)}</span>
+                      </div>
+                      <input
+                        type="range" min="-1" max="1" step="0.1"
+                        value={hsl[col].luminance}
+                        onChange={e => setHsl({ ...hsl, [col]: { ...hsl[col], luminance: parseFloat(e.target.value) } })}
+                        style={{ width: '100%' }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Details</h3>
+
+            <div style={{ paddingBottom: '1rem', borderBottom: '1px solid #222', marginBottom: '1rem' }}>
+              <label style={{ fontSize: '0.8rem', fontWeight: 'bold', display: 'block', marginBottom: '0.5rem', color: '#ccc' }}>Sharpen</label>
+
+              <div style={{ marginBottom: '0.8rem' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Amount</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{sharpenAmount}</span>
+                </div>
+                <input type="range" min="0" max="5.0" step="0.1" value={sharpenAmount} onChange={e => setSharpenAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div style={{ marginBottom: '0.8rem' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Radius</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{sharpenRadius}</span>
+                </div>
+                <input type="range" min="0.1" max="10.0" step="0.1" value={sharpenRadius} onChange={e => setSharpenRadius(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Threshold</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{sharpenThreshold}</span>
+                </div>
+                <input type="range" min="0" max="50" step="1" value={sharpenThreshold} onChange={e => setSharpenThreshold(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
             </div>
 
-            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Clarity</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{clarityAmount}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.05" value={clarityAmount} onChange={e => setClarityAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Dehaze</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{dehazeAmount}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={dehazeAmount} onChange={e => setDehazeAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Vignette</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Amount</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vAmount}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.05" value={vAmount} onChange={e => setVAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Midpoint</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vMidpoint}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={vMidpoint} onChange={e => setVMidpoint(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Roundness</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vRoundness}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.05" value={vRoundness} onChange={e => setVRoundness(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Feather</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{vFeather}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={vFeather} onChange={e => setVFeather(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Grain</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Amount</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{grainAmount}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={grainAmount} onChange={e => setGrainAmount(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <label style={{ fontSize: '0.85rem', display: 'block', marginBottom: '0.3rem' }}>Size</label>
+                <select
+                  value={grainSize}
+                  onChange={e => setGrainSize(e.target.value as 'fine' | 'medium' | 'coarse')}
+                  style={{ width: '100%', background: '#222', color: '#eee', border: '1px solid #444', padding: '4px', borderRadius: '4px' }}
+                >
+                  <option value="fine">Fine</option>
+                  <option value="medium">Medium</option>
+                  <option value="coarse">Coarse</option>
+                </select>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Denoise</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Luminance</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{denoiseLuminance}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={denoiseLuminance} onChange={e => setDenoiseLuminance(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Color</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{denoiseColor}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={denoiseColor} onChange={e => setDenoiseColor(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>LUT</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <input type="file" accept=".cube,.3dl,.xmp,.xml" onChange={handleLutUpload} style={{ fontSize: '0.8rem' }} />
+              {lutName && <span style={{ fontSize: '0.75rem', color: '#4caf50' }}>Loaded: {lutName}</span>}
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Intensity</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{lutIntensity}</span>
+                </div>
+                <input type="range" min="0" max="1" step="0.05" value={lutIntensity} onChange={e => setLutIntensity(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Curves</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Curve Strength</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{curves.intensity}</span>
+                </div>
+                <input data-testid="curve-strength-slider" type="range" min="0" max="1" step="0.05" value={curves.intensity} onChange={e => setCurvesIntensity(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+              <CurveEditor curves={curves} onChange={setCurves} />
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Geometry</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Rotation</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{rotation}°</span>
+                </div>
+                <input data-testid="rotation-slider" type="range" min="-45" max="45" step="1" value={rotation} onChange={e => setRotation(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
+
               <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.85rem' }}>
-                <input type="checkbox" checked={flipHorizontal} onChange={e => setFlipHorizontal(e.target.checked)} />
-                Flip Horizontal
+                <input type="checkbox" checked={autoCrop} onChange={e => setAutoCrop(e.target.checked)} />
+                Auto Crop (Straighten)
               </label>
-              <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.85rem' }}>
-                <input type="checkbox" checked={flipVertical} onChange={e => setFlipVertical(e.target.checked)} />
-                Flip Vertical
-              </label>
-            </div>
-          </div>
-        </section>
 
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Crop</h3>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
-            <div style={{ display: 'flex', gap: '0.5rem' }}>
-              <button onClick={applyCrop} disabled={!!appliedCrop} style={{ flex: 1, padding: '6px', fontSize: '0.8rem' }}>Apply</button>
-              <button onClick={resetCrop} disabled={!appliedCrop} style={{ flex: 1, padding: '6px', fontSize: '0.8rem' }}>Reset</button>
-            </div>
-
-            {!appliedCrop ? (
-              <>
-                <p style={{ fontSize: '0.75rem', color: '#aaa', margin: 0 }}>Adjust red box on canvas.</p>
-                <div>
-                  <label style={{ fontSize: '0.8rem' }}>X: {cropX.toFixed(2)}</label>
-                  <input type="range" min="0" max="1" step="0.01" value={cropX} onChange={e => setCropX(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Vertical Perspective</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{geoVertical}</span>
                 </div>
-                <div>
-                  <label style={{ fontSize: '0.8rem' }}>Y: {cropY.toFixed(2)}</label>
-                  <input type="range" min="0" max="1" step="0.01" value={cropY} onChange={e => setCropY(parseFloat(e.target.value))} style={{ width: '100%' }} />
-                </div>
-                <div>
-                  <label style={{ fontSize: '0.8rem' }}>W: {cropW.toFixed(2)}</label>
-                  <input type="range" min="0" max="1" step="0.01" value={cropW} onChange={e => setCropW(parseFloat(e.target.value))} style={{ width: '100%' }} />
-                </div>
-                <div>
-                  <label style={{ fontSize: '0.8rem' }}>H: {cropH.toFixed(2)}</label>
-                  <input type="range" min="0" max="1" step="0.01" value={cropH} onChange={e => setCropH(parseFloat(e.target.value))} style={{ width: '100%' }} />
-                </div>
-              </>
-            ) : (
-              <div style={{ fontSize: '0.75rem', background: '#222', padding: '0.5rem', borderRadius: '4px' }}>
-                <p style={{ margin: '0 0 0.3rem 0' }}>Crop Applied.</p>
-                <pre style={{ margin: 0 }}>{JSON.stringify(appliedCrop, null, 2)}</pre>
+                <input type="range" min="-1" max="1" step="0.05" value={geoVertical} onChange={e => setGeoVertical(parseFloat(e.target.value))} style={{ width: '100%' }} />
               </div>
-            )}
-          </div>
-        </section>
 
-        <section>
-          <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Histogram</h3>
-          <Histogram data={histogramData} />
-        </section>
+              <div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '0.3rem' }}>
+                  <label style={{ fontSize: '0.85rem' }}>Horizontal Perspective</label>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>{geoHorizontal}</span>
+                </div>
+                <input type="range" min="-1" max="1" step="0.05" value={geoHorizontal} onChange={e => setGeoHorizontal(parseFloat(e.target.value))} style={{ width: '100%' }} />
+              </div>
 
-        <section style={{ opacity: 0.6, fontSize: '0.8rem', borderTop: '1px solid #333', paddingTop: '1rem' }}>
-          <h4 style={{ margin: '0 0 0.5rem 0' }}>Debug Info</h4>
-          <div>WB Mode: {isPickingWB ? 'ACTIVE' : 'Inactive'}</div>
-          <div>Canvas: {canvasRef.current ? `${canvasRef.current.width}x${canvasRef.current.height}` : 'N/A'}</div>
-          <div>Image: {image ? `${image.width}x${image.height}` : 'N/A'}</div>
-        </section>
-      </aside>
-    </div>
-  </div >
-);
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.85rem' }}>
+                  <input type="checkbox" checked={flipHorizontal} onChange={e => setFlipHorizontal(e.target.checked)} />
+                  Flip Horizontal
+                </label>
+                <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.85rem' }}>
+                  <input type="checkbox" checked={flipVertical} onChange={e => setFlipVertical(e.target.checked)} />
+                  Flip Vertical
+                </label>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Crop</h3>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '0.8rem' }}>
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <button onClick={applyCrop} disabled={!!appliedCrop} style={{ flex: 1, padding: '6px', fontSize: '0.8rem' }}>Apply</button>
+                <button onClick={resetCrop} disabled={!appliedCrop} style={{ flex: 1, padding: '6px', fontSize: '0.8rem' }}>Reset</button>
+              </div>
+
+              {!appliedCrop ? (
+                <>
+                  <p style={{ fontSize: '0.75rem', color: '#aaa', margin: 0 }}>Adjust red box on canvas.</p>
+                  <div>
+                    <label style={{ fontSize: '0.8rem' }}>X: {cropX.toFixed(2)}</label>
+                    <input type="range" min="0" max="1" step="0.01" value={cropX} onChange={e => setCropX(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                  </div>
+                  <div>
+                    <label style={{ fontSize: '0.8rem' }}>Y: {cropY.toFixed(2)}</label>
+                    <input type="range" min="0" max="1" step="0.01" value={cropY} onChange={e => setCropY(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                  </div>
+                  <div>
+                    <label style={{ fontSize: '0.8rem' }}>W: {cropW.toFixed(2)}</label>
+                    <input type="range" min="0" max="1" step="0.01" value={cropW} onChange={e => setCropW(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                  </div>
+                  <div>
+                    <label style={{ fontSize: '0.8rem' }}>H: {cropH.toFixed(2)}</label>
+                    <input type="range" min="0" max="1" step="0.01" value={cropH} onChange={e => setCropH(parseFloat(e.target.value))} style={{ width: '100%' }} />
+                  </div>
+                </>
+              ) : (
+                <div style={{ fontSize: '0.75rem', background: '#222', padding: '0.5rem', borderRadius: '4px' }}>
+                  <p style={{ margin: '0 0 0.3rem 0' }}>Crop Applied.</p>
+                  <pre style={{ margin: 0 }}>{JSON.stringify(appliedCrop, null, 2)}</pre>
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <h3 style={{ margin: '0 0 1rem 0', fontSize: '1rem', borderBottom: '1px solid #333', paddingBottom: '0.5rem' }}>Histogram</h3>
+            <Histogram data={histogramData} />
+          </section>
+
+          <section style={{ opacity: 0.6, fontSize: '0.8rem', borderTop: '1px solid #333', paddingTop: '1rem' }}>
+            <h4 style={{ margin: '0 0 0.5rem 0' }}>Debug Info</h4>
+            <div>WB Mode: {isPickingWB ? 'ACTIVE' : 'Inactive'}</div>
+            <div>Canvas: {canvasRef.current ? `${canvasRef.current.width}x${canvasRef.current.height}` : 'N/A'}</div>
+            <div>Image: {image ? `${image.width}x${image.height}` : 'N/A'}</div>
+          </section>
+        </aside>
+      </div>
+    </div >
+  );
 }
 
 export default App;

--- a/quickfix-renderer/src/lib.rs
+++ b/quickfix-renderer/src/lib.rs
@@ -228,7 +228,7 @@ pub struct DehazeSettings {
 pub struct LensDistortionSettings {
     pub k1: f32, // Main radial distortion
     pub k2: f32, // Secondary radial distortion
-    // We could add centers or scale, but let's stick to k1/k2 for now
+                 // We could add centers or scale, but let's stick to k1/k2 for now
 }
 
 #[wasm_bindgen(typescript_custom_section)]

--- a/quickfix-renderer/src/lib.rs
+++ b/quickfix-renderer/src/lib.rs
@@ -185,7 +185,18 @@ pub struct QuickFixAdjustments {
     pub grain: Option<GrainSettings>,
     pub geometry: Option<GeometrySettings>,
     pub denoise: Option<DenoiseSettings>,
+
     pub lut: Option<Lut3DSettings>,
+    pub vignette: Option<VignetteSettings>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct VignetteSettings {
+    pub amount: f32, // 0.0 to 1.0 (or -1.0 to 1.0 if supporting white vignette?) Users usually want dark. Let's assume -1.0 to 1.0 where < 0 is dark.
+    pub midpoint: f32, // 0.0 to 1.0 (size of clear area)
+    pub roundness: f32, // -1.0 to 1.0 (shape, square vs circle)
+    pub feather: f32, // 0.0 to 1.0 (smoothness)
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -286,6 +297,13 @@ export interface SplitToningSettings {
     balance: number;
 }
 
+export interface VignetteSettings {
+    amount: number;
+    midpoint: number;
+    roundness: number;
+    feather: number;
+}
+
 export interface ChannelCurve {
     points: CurvePoint[];
 }
@@ -306,6 +324,7 @@ export interface QuickFixAdjustments {
     geometry?: GeometrySettings;
     denoise?: DenoiseSettings;
     lut?: Lut3DSettings;
+    vignette?: VignetteSettings;
 }
 "#;
 

--- a/quickfix-renderer/src/lib.rs
+++ b/quickfix-renderer/src/lib.rs
@@ -144,11 +144,33 @@ pub struct CurvesSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+pub struct HslRangeSettings {
+    pub hue: f32, // Offset degrees or normalized? Let's use -1.0 to 1.0 (mapped to e.g. -30 to 30 deg)
+    pub saturation: f32, // -1.0 to 1.0 (offset)
+    pub luminance: f32, // -1.0 to 1.0 (offset)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HslSettings {
+    pub red: HslRangeSettings,
+    pub orange: HslRangeSettings,
+    pub yellow: HslRangeSettings,
+    pub green: HslRangeSettings,
+    pub aqua: HslRangeSettings,
+    pub blue: HslRangeSettings,
+    pub purple: HslRangeSettings,
+    pub magenta: HslRangeSettings,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct QuickFixAdjustments {
     pub crop: Option<CropSettings>,
     pub exposure: Option<ExposureSettings>,
     pub color: Option<ColorSettings>,
     pub curves: Option<CurvesSettings>,
+    pub hsl: Option<HslSettings>,
     pub grain: Option<GrainSettings>,
     pub geometry: Option<GeometrySettings>,
     pub denoise: Option<DenoiseSettings>,
@@ -228,6 +250,23 @@ export interface CurvesSettings {
     blue?: ChannelCurve;
 }
 
+export interface HslRangeSettings {
+    hue: number;
+    saturation: number;
+    luminance: number;
+}
+
+export interface HslSettings {
+    red: HslRangeSettings;
+    orange: HslRangeSettings;
+    yellow: HslRangeSettings;
+    green: HslRangeSettings;
+    aqua: HslRangeSettings;
+    blue: HslRangeSettings;
+    purple: HslRangeSettings;
+    magenta: HslRangeSettings;
+}
+
 export interface ChannelCurve {
     points: CurvePoint[];
 }
@@ -242,6 +281,7 @@ export interface QuickFixAdjustments {
     exposure?: ExposureSettings;
     color?: ColorSettings;
     curves?: CurvesSettings;
+    hsl?: HslSettings;
     grain?: GrainSettings;
     geometry?: GeometrySettings;
     denoise?: DenoiseSettings;

--- a/quickfix-renderer/src/lib.rs
+++ b/quickfix-renderer/src/lib.rs
@@ -191,6 +191,7 @@ pub struct QuickFixAdjustments {
     pub sharpen: Option<SharpenSettings>,
     pub clarity: Option<ClaritySettings>,
     pub dehaze: Option<DehazeSettings>,
+    pub distortion: Option<LensDistortionSettings>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -220,6 +221,14 @@ pub struct ClaritySettings {
 #[serde(rename_all = "camelCase")]
 pub struct DehazeSettings {
     pub amount: f32, // 0.0 to 1.0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct LensDistortionSettings {
+    pub k1: f32, // Main radial distortion
+    pub k2: f32, // Secondary radial distortion
+    // We could add centers or scale, but let's stick to k1/k2 for now
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -341,6 +350,11 @@ export interface DehazeSettings {
     amount: number;
 }
 
+export interface LensDistortionSettings {
+    k1: number;
+    k2: number;
+}
+
 export interface ChannelCurve {
     points: CurvePoint[];
 }
@@ -365,6 +379,7 @@ export interface QuickFixAdjustments {
     sharpen?: SharpenSettings;
     clarity?: ClaritySettings;
     dehaze?: DehazeSettings;
+    distortion?: LensDistortionSettings;
 }
 
 "#;

--- a/quickfix-renderer/src/lib.rs
+++ b/quickfix-renderer/src/lib.rs
@@ -152,6 +152,16 @@ pub struct HslRangeSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+pub struct SplitToningSettings {
+    pub shadow_hue: f32,    // 0..360
+    pub shadow_sat: f32,    // 0..1
+    pub highlight_hue: f32, // 0..360
+    pub highlight_sat: f32, // 0..1
+    pub balance: f32,       // -1..1
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct HslSettings {
     pub red: HslRangeSettings,
     pub orange: HslRangeSettings,
@@ -171,6 +181,7 @@ pub struct QuickFixAdjustments {
     pub color: Option<ColorSettings>,
     pub curves: Option<CurvesSettings>,
     pub hsl: Option<HslSettings>,
+    pub split_toning: Option<SplitToningSettings>,
     pub grain: Option<GrainSettings>,
     pub geometry: Option<GeometrySettings>,
     pub denoise: Option<DenoiseSettings>,
@@ -267,6 +278,14 @@ export interface HslSettings {
     magenta: HslRangeSettings;
 }
 
+export interface SplitToningSettings {
+    shadowHue: number;
+    shadowSat: number;
+    highlightHue: number;
+    highlightSat: number;
+    balance: number;
+}
+
 export interface ChannelCurve {
     points: CurvePoint[];
 }
@@ -282,6 +301,7 @@ export interface QuickFixAdjustments {
     color?: ColorSettings;
     curves?: CurvesSettings;
     hsl?: HslSettings;
+    splitToning?: SplitToningSettings;
     grain?: GrainSettings;
     geometry?: GeometrySettings;
     denoise?: DenoiseSettings;

--- a/quickfix-renderer/src/lib.rs
+++ b/quickfix-renderer/src/lib.rs
@@ -188,6 +188,9 @@ pub struct QuickFixAdjustments {
 
     pub lut: Option<Lut3DSettings>,
     pub vignette: Option<VignetteSettings>,
+    pub sharpen: Option<SharpenSettings>,
+    pub clarity: Option<ClaritySettings>,
+    pub dehaze: Option<DehazeSettings>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -197,6 +200,26 @@ pub struct VignetteSettings {
     pub midpoint: f32, // 0.0 to 1.0 (size of clear area)
     pub roundness: f32, // -1.0 to 1.0 (shape, square vs circle)
     pub feather: f32, // 0.0 to 1.0 (smoothness)
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct SharpenSettings {
+    pub amount: f32,    // 0.0 to 1.0 (or higher)
+    pub radius: f32,    // 0.0 to ... px
+    pub threshold: f32, // 0.0 to 255.0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ClaritySettings {
+    pub amount: f32, // -1.0 to 1.0
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct DehazeSettings {
+    pub amount: f32, // 0.0 to 1.0
 }
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -304,6 +327,20 @@ export interface VignetteSettings {
     feather: number;
 }
 
+export interface SharpenSettings {
+    amount: number;
+    radius: number;
+    threshold: number;
+}
+
+export interface ClaritySettings {
+    amount: number;
+}
+
+export interface DehazeSettings {
+    amount: number;
+}
+
 export interface ChannelCurve {
     points: CurvePoint[];
 }
@@ -325,7 +362,11 @@ export interface QuickFixAdjustments {
     denoise?: DenoiseSettings;
     lut?: Lut3DSettings;
     vignette?: VignetteSettings;
+    sharpen?: SharpenSettings;
+    clarity?: ClaritySettings;
+    dehaze?: DehazeSettings;
 }
+
 "#;
 
 impl QuickFixAdjustments {

--- a/quickfix-renderer/src/operations.rs
+++ b/quickfix-renderer/src/operations.rs
@@ -1,7 +1,7 @@
 use crate::{
-    ColorSettings, CropSettings, CurvesSettings, DenoiseSettings, ExposureSettings,
-    GeometrySettings, GrainSettings, HslSettings, QuickFixAdjustments, SplitToningSettings,
-    VignetteSettings,
+    ClaritySettings, ColorSettings, CropSettings, CurvesSettings, DehazeSettings, DenoiseSettings,
+    ExposureSettings, GeometrySettings, GrainSettings, HslSettings, QuickFixAdjustments,
+    SharpenSettings, SplitToningSettings, VignetteSettings,
 };
 use image::{ImageBuffer, Rgba, RgbaImage};
 use rand::SeedableRng;
@@ -89,6 +89,16 @@ pub fn process_frame_internal(
         apply_split_toning_in_place(&mut img, st);
     }
 
+    // 7.6 Dehaze
+    if let Some(dehaze) = &adjustments.dehaze {
+        apply_dehaze_in_place(&mut img, dehaze);
+    }
+
+    // 7.7 Clarity
+    if let Some(clarity) = &adjustments.clarity {
+        apply_clarity_in_place(&mut img, clarity);
+    }
+
     // 8. LUT
     if let (Some(lut_settings), Some((lut_data, lut_size))) = (&adjustments.lut, lut_buffer) {
         apply_lut_in_place(&mut img, lut_data, lut_size, lut_settings);
@@ -97,6 +107,11 @@ pub fn process_frame_internal(
     // 8.5 Vignette
     if let Some(vignette) = &adjustments.vignette {
         apply_vignette_in_place(&mut img, vignette);
+    }
+
+    // 8.6 Sharpen
+    if let Some(sharpen) = &adjustments.sharpen {
+        apply_sharpen_in_place(&mut img, sharpen);
     }
 
     // 9. Grain
@@ -1169,12 +1184,246 @@ pub(crate) fn apply_vignette_in_place(img: &mut RgbaImage, settings: &VignetteSe
     }
 }
 
+pub(crate) fn apply_sharpen_in_place(img: &mut RgbaImage, settings: &SharpenSettings) {
+    if settings.amount <= 0.0 {
+        return;
+    }
+
+    let radius = settings.radius.max(0.1);
+    // Use standard gaussian blur for sharpening (usually small radius)
+    // image::imageops::blur uses Gaussian
+    let blurred = image::imageops::blur(img, radius);
+
+    let threshold = settings.threshold;
+
+    for (x, y, pixel) in img.enumerate_pixels_mut() {
+        let blur_px = blurred.get_pixel(x, y);
+
+        for c in 0..3 {
+            let val = pixel[c] as f32;
+            let blur_val = blur_px[c] as f32;
+
+            let diff = val - blur_val;
+            if diff.abs() * 255.0 >= threshold {
+                let new_val = val + diff * settings.amount;
+                pixel[c] = clamp_u8(new_val);
+            }
+        }
+    }
+}
+
+pub(crate) fn apply_clarity_in_place(img: &mut RgbaImage, settings: &ClaritySettings) {
+    if settings.amount.abs() < 1e-4 {
+        return;
+    }
+
+    let (width, height) = img.dimensions();
+    // Large radius for local contrast
+    let radius = (width.min(height) as f32 / 64.0).clamp(8.0, 100.0);
+
+    // Use fast box blur approximation (1 pass is often enough for clarity effect,
+    // but 3 passes is smoother. Let's do 2 passes for speed/quality balance)
+    let blurred = fast_box_blur(img, radius as u32);
+    // let blurred = fast_box_blur(&blurred, radius as u32); // Second pass if needed
+
+    for (x, y, pixel) in img.enumerate_pixels_mut() {
+        let blur_px = blurred.get_pixel(x, y);
+
+        // Apply to RGB roughly or specific channel?
+        // Simple Unsharp Mask logic
+        for c in 0..3 {
+            let val = pixel[c] as f32;
+            let blur_val = blur_px[c] as f32;
+            let diff = val - blur_val;
+
+            // Clarity typically adds mid-tone contrast using Soft Light or Overlay blending of High Pass
+            // Or just straight unsharp mask.
+            let new_val = val + diff * settings.amount;
+            pixel[c] = clamp_u8(new_val);
+        }
+    }
+}
+
+pub(crate) fn apply_dehaze_in_place(img: &mut RgbaImage, settings: &DehazeSettings) {
+    if settings.amount <= 0.0 {
+        return;
+    }
+
+    // Simple Dehaze: "De-fog"
+    // Concept: Haze adds a white veil. Dark regions get brighter.
+    // 1. Estimate Veil: Dark Channel.
+    // 2. Subtract Veil.
+
+    let amount = clamp(settings.amount, 0.0, 1.0) * 0.95; // Limit max amount
+
+    // Optimisation: We can just do per-pixel operation for speed
+    // T(x) = 1 - w * min(r,g,b)
+    // J(x) = (I(x) - A) / max(T(x), 0.1) + A
+    // Taking A = 1.0 (255) approx.
+
+    for pixel in img.pixels_mut() {
+        let r = pixel[0] as f32 / 255.0;
+        let g = pixel[1] as f32 / 255.0;
+        let b = pixel[2] as f32 / 255.0;
+
+        let dark = r.min(g).min(b);
+        let transm = 1.0 - amount * dark;
+        let transm = transm.max(0.1); // Prevent div by zero
+
+        // Recover: J = (I - 1) / t + 1
+        // (Assuming Atmosphere is white)
+        let r_new = (r - 1.0) / transm + 1.0;
+        let g_new = (g - 1.0) / transm + 1.0;
+        let b_new = (b - 1.0) / transm + 1.0;
+
+        pixel[0] = clamp_u8(r_new * 255.0);
+        pixel[1] = clamp_u8(g_new * 255.0);
+        pixel[2] = clamp_u8(b_new * 255.0);
+    }
+}
+
+fn fast_box_blur(img: &RgbaImage, radius: u32) -> RgbaImage {
+    let (width, height) = img.dimensions();
+    if radius == 0 {
+        return img.clone();
+    }
+
+    let r = radius as i32;
+
+    // Simpler separative blur implementation
+    // Creates intermediate buffer
+    let mut h_blur = RgbaImage::new(width, height);
+
+    // Horizontal
+    for y in 0..height {
+        let mut sum_r: u32 = 0;
+        let mut sum_g: u32 = 0;
+        let mut sum_b: u32 = 0;
+        let mut count: u32 = 0;
+
+        // Initial window for x=0
+        for i in -r..=r {
+            let ix = i.clamp(0, width as i32 - 1) as u32;
+            let px = img.get_pixel(ix, y);
+            sum_r += px[0] as u32;
+            sum_g += px[1] as u32;
+            sum_b += px[2] as u32;
+            count += 1;
+        }
+
+        // This naïve window re-summing is O(R*W). Sliding window is O(W).
+        // For radius ~20, O(R*W) is okay but let's try to be efficient.
+        // But implementing correct sliding window with boundary clamping is verbose.
+        // Let's do O(W) sliding window.
+
+        // Prepare first window [0-r, 0+r].
+        // current sum is sum([0-r..0+r]).
+        // Actually, clamp means we read pixel 0 for negative indices.
+        // sum_r already computed above with clamp.
+
+        h_blur.put_pixel(
+            0,
+            y,
+            Rgba([
+                (sum_r / count) as u8,
+                (sum_g / count) as u8,
+                (sum_b / count) as u8,
+                255,
+            ]),
+        );
+
+        for x in 1..width {
+            // Remove x-r-1
+            let out_idx = (x as i32 - r - 1).clamp(0, width as i32 - 1) as u32;
+            let p_out = img.get_pixel(out_idx, y);
+            sum_r -= p_out[0] as u32;
+            sum_g -= p_out[1] as u32;
+            sum_b -= p_out[2] as u32;
+
+            // Add x+r
+            let in_idx = (x as i32 + r).clamp(0, width as i32 - 1) as u32;
+            let p_in = img.get_pixel(in_idx, y);
+            sum_r += p_in[0] as u32;
+            sum_g += p_in[1] as u32;
+            sum_b += p_in[2] as u32;
+
+            h_blur.put_pixel(
+                x,
+                y,
+                Rgba([
+                    (sum_r / count) as u8,
+                    (sum_g / count) as u8,
+                    (sum_b / count) as u8,
+                    255,
+                ]),
+            );
+        }
+    }
+
+    let mut v_blur = RgbaImage::new(width, height);
+    // Vertical
+    for x in 0..width {
+        let mut sum_r: u32 = 0;
+        let mut sum_g: u32 = 0;
+        let mut sum_b: u32 = 0;
+        let mut count: u32 = 0;
+
+        for i in -r..=r {
+            let iy = i.clamp(0, height as i32 - 1) as u32;
+            let px = h_blur.get_pixel(x, iy);
+            sum_r += px[0] as u32;
+            sum_g += px[1] as u32;
+            sum_b += px[2] as u32;
+            count += 1;
+        }
+
+        v_blur.put_pixel(
+            x,
+            0,
+            Rgba([
+                (sum_r / count) as u8,
+                (sum_g / count) as u8,
+                (sum_b / count) as u8,
+                255,
+            ]),
+        );
+
+        for y in 1..height {
+            let out_idx = (y as i32 - r - 1).clamp(0, height as i32 - 1) as u32;
+            let p_out = h_blur.get_pixel(x, out_idx);
+            sum_r -= p_out[0] as u32;
+            sum_g -= p_out[1] as u32;
+            sum_b -= p_out[2] as u32;
+
+            let in_idx = (y as i32 + r).clamp(0, height as i32 - 1) as u32;
+            let p_in = h_blur.get_pixel(x, in_idx);
+            sum_r += p_in[0] as u32;
+            sum_g += p_in[1] as u32;
+            sum_b += p_in[2] as u32;
+
+            let p_orig = img.get_pixel(x, y); // Preserve original alpha
+            v_blur.put_pixel(
+                x,
+                y,
+                Rgba([
+                    (sum_r / count) as u8,
+                    (sum_g / count) as u8,
+                    (sum_b / count) as u8,
+                    p_orig[3],
+                ]),
+            );
+        }
+    }
+
+    v_blur
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        ChannelCurve, ColorSettings, CropRect, CropSettings, CurvePoint, CurvesSettings,
-        ExposureSettings, GeometrySettings,
+        ClaritySettings, DehazeSettings, GeometrySettings, GrainSettings, HslSettings,
+        QuickFixAdjustments, SharpenSettings, SplitToningSettings, VignetteSettings,
     };
 
     fn create_test_image(width: u32, height: u32, color: [u8; 4]) -> RgbaImage {
@@ -1555,5 +1804,89 @@ mod tests {
         // Verify output is grayish (keeps saturation balance on white image)
         assert_eq!(corner[0], corner[1]);
         assert_eq!(corner[1], corner[2]);
+    }
+    #[test]
+    fn test_apply_sharpen() {
+        // Create a blurry image or just an edge.
+        // Let's create a step function (edge).
+        let width = 10;
+        let height = 10;
+        let mut img = create_test_image(width, height, [100, 100, 100, 255]);
+        // Right half bright
+        for y in 0..height {
+            for x in width / 2..width {
+                img.put_pixel(x, y, Rgba([200, 200, 200, 255]));
+            }
+        }
+
+        let settings = SharpenSettings {
+            amount: 1.0,
+            radius: 1.0,
+            threshold: 0.0,
+        };
+
+        // Sharpening should increase contrast at the edge.
+        // The pixel just to the left of the edge (x=4) should get darker (100 -> <100)
+        // The pixel just to the right of the edge (x=5) should get brighter (200 -> >200)
+
+        // Before: x=4 is 100. x=5 is 200.
+        apply_sharpen_in_place(&mut img, &settings);
+
+        let p_left = img.get_pixel(4, 5);
+        let p_right = img.get_pixel(5, 5);
+
+        assert!(p_left[0] < 100);
+        assert!(p_right[0] > 200);
+    }
+
+    #[test]
+    fn test_apply_clarity() {
+        // Clarity boosts local contrast.
+        // Similar to sharpen but large radius.
+        let width = 20;
+        let height = 20;
+        let mut img = create_test_image(width, height, [100, 100, 100, 255]);
+        // Center bright spot
+        for y in 5..15 {
+            for x in 5..15 {
+                img.put_pixel(x, y, Rgba([150, 150, 150, 255]));
+            }
+        }
+
+        let settings = ClaritySettings { amount: 0.5 };
+        apply_clarity_in_place(&mut img, &settings);
+
+        // Center pixel (10,10) is 150. Surround is 100.
+        // Blur will average them (e.g. 125).
+        // Difference = 150 - 125 = +25.
+        // New = 150 + 25*0.5 = 162.5.
+        // So center should get brighter.
+        let center = img.get_pixel(10, 10);
+        assert!(center[0] > 150);
+
+        // Verify it doesn't effect uniform area much?
+        // Fast box blur might have edge effects but internal uniform area should be close to uniform blur = pixel.
+        // so diff = 0.
+        // But our test image is small, so radius might cover everything.
+    }
+
+    #[test]
+    fn test_apply_dehaze() {
+        // Create an image with haze (elevated dark channel)
+        // e.g. RGB(200, 200, 210) - kinda whitish/grayish
+        let mut img = create_test_image(1, 1, [200, 200, 210, 255]);
+
+        let settings = DehazeSettings { amount: 0.5 };
+        apply_dehaze_in_place(&mut img, &settings);
+
+        let px = img.get_pixel(0, 0);
+
+        // Dark channel of [200, 200, 210] is 200 (approx 0.78).
+        // Transm = 1.0 - 0.5 * 0.78 = 0.61.
+        // Recover: (0.78 - 1.0) / 0.61 + 1.0 = -0.22 / 0.61 + 1.0 = -0.36 + 1.0 = 0.64 -> 163.
+        // So values should drop (contrast stretching downward).
+        assert!(px[0] < 200);
+        assert!(px[1] < 200);
+        assert!(px[2] < 210);
     }
 }

--- a/quickfix-renderer/src/operations.rs
+++ b/quickfix-renderer/src/operations.rs
@@ -82,7 +82,7 @@ pub fn process_frame_internal(
     if let Some(hsl) = &adjustments.hsl {
         apply_hsl_in_place(&mut img, hsl);
     }
-    
+
     // 7.5 Split Toning
     if let Some(st) = &adjustments.split_toning {
         apply_split_toning_in_place(&mut img, st);
@@ -1043,13 +1043,12 @@ pub(crate) fn apply_split_toning_in_place(img: &mut RgbaImage, settings: &SplitT
             if blend < 0.5 {
                 base - (1.0 - 2.0 * blend) * base * (1.0 - base)
             } else {
-                base + (2.0 * blend - 1.0) * ((base.sqrt().max(base) - base) * base + base - base)
-                // Simplified soft light
-                base + (2.0 * blend - 1.0) * (if base <= 0.25 {
-                    ((16.0 * base - 12.0) * base + 4.0) * base
-                } else {
-                    base.sqrt()
-                } - base)
+                base + (2.0 * blend - 1.0)
+                    * (if base <= 0.25 {
+                        ((16.0 * base - 12.0) * base + 4.0) * base
+                    } else {
+                        base.sqrt()
+                    } - base)
             }
         }
 
@@ -1066,12 +1065,12 @@ pub(crate) fn apply_split_toning_in_place(img: &mut RgbaImage, settings: &SplitT
 
         // Apply Highlight Tint
         if highlight_s > 0.0 {
-            r_out =
-                soft_light(r_out, highlight_rgb[0]) * highlight_mask + r_out * (1.0 - highlight_mask);
-            g_out =
-                soft_light(g_out, highlight_rgb[1]) * highlight_mask + g_out * (1.0 - highlight_mask);
-            b_out =
-                soft_light(b_out, highlight_rgb[2]) * highlight_mask + b_out * (1.0 - highlight_mask);
+            r_out = soft_light(r_out, highlight_rgb[0]) * highlight_mask
+                + r_out * (1.0 - highlight_mask);
+            g_out = soft_light(g_out, highlight_rgb[1]) * highlight_mask
+                + g_out * (1.0 - highlight_mask);
+            b_out = soft_light(b_out, highlight_rgb[2]) * highlight_mask
+                + b_out * (1.0 - highlight_mask);
         }
 
         pixel[0] = clamp_u8(r_out * 255.0);
@@ -1423,7 +1422,7 @@ mod tests {
     fn test_apply_split_toning() {
         let mut img = create_test_image(1, 1, [128, 128, 128, 255]); // Mid gray
         let settings = SplitToningSettings {
-            shadow_hue: 200.0,    // Teal
+            shadow_hue: 200.0, // Teal
             shadow_sat: 0.5,
             highlight_hue: 30.0, // Orange
             highlight_sat: 0.5,
@@ -1431,8 +1430,8 @@ mod tests {
         };
         apply_split_toning_in_place(&mut img, &settings);
         let px = img.get_pixel(0, 0);
-        
-        // Mid gray should be affected by both (or neutral if masks are 0 at midpoint, 
+
+        // Mid gray should be affected by both (or neutral if masks are 0 at midpoint,
         // but our masks overlap mid).
         // Let's just verify it changed.
         assert!(px[0] != 128 || px[1] != 128 || px[2] != 128);

--- a/quickfix-renderer/src/webgl.rs
+++ b/quickfix-renderer/src/webgl.rs
@@ -751,6 +751,21 @@ impl WebGlRenderer {
             gl.uniform_4_f32_slice(loc("u_hsl").as_ref(), &hsl_data);
         }
 
+        // Split Toning
+        if let Some(st) = &settings.split_toning {
+            gl.uniform_1_f32(loc("u_st_shadow_hue").as_ref(), st.shadow_hue);
+            gl.uniform_1_f32(loc("u_st_shadow_sat").as_ref(), st.shadow_sat);
+            gl.uniform_1_f32(loc("u_st_highlight_hue").as_ref(), st.highlight_hue);
+            gl.uniform_1_f32(loc("u_st_highlight_sat").as_ref(), st.highlight_sat);
+            gl.uniform_1_f32(loc("u_st_balance").as_ref(), st.balance);
+        } else {
+            gl.uniform_1_f32(loc("u_st_shadow_hue").as_ref(), 0.0);
+            gl.uniform_1_f32(loc("u_st_shadow_sat").as_ref(), 0.0);
+            gl.uniform_1_f32(loc("u_st_highlight_hue").as_ref(), 0.0);
+            gl.uniform_1_f32(loc("u_st_highlight_sat").as_ref(), 0.0);
+            gl.uniform_1_f32(loc("u_st_balance").as_ref(), 0.0);
+        }
+
         gl.uniform_2_f32(loc("u_src_size").as_ref(), width as f32, height as f32);
 
         gl.viewport(0, 0, width as i32, height as i32);

--- a/quickfix-renderer/src/webgl.rs
+++ b/quickfix-renderer/src/webgl.rs
@@ -700,6 +700,57 @@ impl WebGlRenderer {
             loc("u_curves_intensity").as_ref(),
             settings.curves.as_ref().map(|c| c.intensity).unwrap_or(1.0),
         );
+
+        // HSL
+        if let Some(hsl) = &settings.hsl {
+            let centers = [
+                0.0 / 360.0,
+                30.0 / 360.0,
+                60.0 / 360.0,
+                120.0 / 360.0,
+                180.0 / 360.0,
+                240.0 / 360.0,
+                270.0 / 360.0,
+                300.0 / 360.0,
+            ];
+            let ranges = [
+                &hsl.red,
+                &hsl.orange,
+                &hsl.yellow,
+                &hsl.green,
+                &hsl.aqua,
+                &hsl.blue,
+                &hsl.purple,
+                &hsl.magenta,
+            ];
+
+            let mut hsl_data = [0.0f32; 32];
+            for i in 0..8 {
+                hsl_data[i * 4] = ranges[i].hue;
+                hsl_data[i * 4 + 1] = ranges[i].saturation;
+                hsl_data[i * 4 + 2] = ranges[i].luminance;
+                hsl_data[i * 4 + 3] = centers[i];
+            }
+            gl.uniform_4_f32_slice(loc("u_hsl").as_ref(), &hsl_data);
+        } else {
+            // Identity HSL
+            let mut hsl_data = [0.0f32; 32];
+            let centers = [
+                0.0 / 360.0,
+                30.0 / 360.0,
+                60.0 / 360.0,
+                120.0 / 360.0,
+                180.0 / 360.0,
+                240.0 / 360.0,
+                270.0 / 360.0,
+                300.0 / 360.0,
+            ];
+            for i in 0..8 {
+                hsl_data[i * 4 + 3] = centers[i];
+            }
+            gl.uniform_4_f32_slice(loc("u_hsl").as_ref(), &hsl_data);
+        }
+
         gl.uniform_2_f32(loc("u_src_size").as_ref(), width as f32, height as f32);
 
         gl.viewport(0, 0, width as i32, height as i32);

--- a/quickfix-renderer/src/webgl.rs
+++ b/quickfix-renderer/src/webgl.rs
@@ -697,6 +697,7 @@ impl WebGlRenderer {
             settings.denoise.as_ref().map(|d| d.color).unwrap_or(0.0),
         );
         gl.uniform_1_f32(
+            loc("u_curves_intensity").as_ref(),
             settings.curves.as_ref().map(|c| c.intensity).unwrap_or(1.0),
         );
 

--- a/quickfix-renderer/src/webgl.rs
+++ b/quickfix-renderer/src/webgl.rs
@@ -697,8 +697,16 @@ impl WebGlRenderer {
             settings.denoise.as_ref().map(|d| d.color).unwrap_or(0.0),
         );
         gl.uniform_1_f32(
-            loc("u_curves_intensity").as_ref(),
             settings.curves.as_ref().map(|c| c.intensity).unwrap_or(1.0),
+        );
+
+        gl.uniform_1_f32(
+            loc("u_distortion_k1").as_ref(),
+            settings.distortion.as_ref().map(|d| d.k1).unwrap_or(0.0),
+        );
+        gl.uniform_1_f32(
+            loc("u_distortion_k2").as_ref(),
+            settings.distortion.as_ref().map(|d| d.k2).unwrap_or(0.0),
         );
 
         // HSL

--- a/quickfix-renderer/src/webgl.rs
+++ b/quickfix-renderer/src/webgl.rs
@@ -710,6 +710,11 @@ impl WebGlRenderer {
             settings.distortion.as_ref().map(|d| d.k2).unwrap_or(0.0),
         );
 
+        gl.uniform_1_f32(
+            loc("u_hsl_enabled").as_ref(),
+            if settings.hsl.is_some() { 1.0 } else { 0.0 },
+        );
+
         // HSL
         if let Some(hsl) = &settings.hsl {
             let centers = [

--- a/quickfix-renderer/src/webgpu.rs
+++ b/quickfix-renderer/src/webgpu.rs
@@ -40,7 +40,7 @@ struct SettingsUniform {
     _padding: f32,
     distortion_k1: f32,
     distortion_k2: f32,
-    _padding_align: f32,
+    hsl_enabled: f32,
     hsl: [[f32; 4]; 8],
 }
 
@@ -578,7 +578,7 @@ impl Renderer for WebGpuRenderer {
             _padding: 0.0,
             distortion_k1: settings.distortion.as_ref().map(|d| d.k1).unwrap_or(0.0),
             distortion_k2: settings.distortion.as_ref().map(|d| d.k2).unwrap_or(0.0),
-            _padding_align: 0.0,
+            hsl_enabled: if settings.hsl.is_some() { 1.0 } else { 0.0 },
             hsl: {
                 let mut hsl_data = [[0.0f32; 4]; 8];
                 let centers = [

--- a/quickfix-renderer/src/webgpu.rs
+++ b/quickfix-renderer/src/webgpu.rs
@@ -548,6 +548,33 @@ impl Renderer for WebGpuRenderer {
             denoise_color: settings.denoise.as_ref().map(|d| d.color).unwrap_or(0.0),
             curves_intensity: settings.curves.as_ref().map(|c| c.intensity).unwrap_or(1.0),
             _padding: 0.0,
+            st_shadow_hue: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.shadow_hue / 360.0)
+                .unwrap_or(0.0),
+            st_shadow_sat: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.shadow_sat)
+                .unwrap_or(0.0),
+            st_highlight_hue: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.highlight_hue / 360.0)
+                .unwrap_or(0.0),
+            st_highlight_sat: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.highlight_sat)
+                .unwrap_or(0.0),
+            st_balance: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.balance)
+                .unwrap_or(0.0),
+            _padding2: 0.0,
+            _padding3: 0.0,
             hsl: {
                 let mut hsl_data = [[0.0f32; 4]; 8];
                 let centers = [
@@ -1037,6 +1064,33 @@ impl Renderer for WebGpuRenderer {
             denoise_color: settings.denoise.as_ref().map(|d| d.color).unwrap_or(0.0),
             curves_intensity: settings.curves.as_ref().map(|c| c.intensity).unwrap_or(1.0),
             _padding: 0.0,
+            st_shadow_hue: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.shadow_hue / 360.0)
+                .unwrap_or(0.0),
+            st_shadow_sat: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.shadow_sat)
+                .unwrap_or(0.0),
+            st_highlight_hue: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.highlight_hue / 360.0)
+                .unwrap_or(0.0),
+            st_highlight_sat: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.highlight_sat)
+                .unwrap_or(0.0),
+            st_balance: settings
+                .split_toning
+                .as_ref()
+                .map(|s| s.balance)
+                .unwrap_or(0.0),
+            _padding2: 0.0,
+            _padding3: 0.0,
             hsl: {
                 let mut hsl_data = [[0.0f32; 4]; 8];
                 let centers = [

--- a/quickfix-renderer/src/webgpu.rs
+++ b/quickfix-renderer/src/webgpu.rs
@@ -549,7 +549,7 @@ impl Renderer for WebGpuRenderer {
                 .unwrap_or(0.0),
             denoise_color: settings.denoise.as_ref().map(|d| d.color).unwrap_or(0.0),
             curves_intensity: settings.curves.as_ref().map(|c| c.intensity).unwrap_or(1.0),
-            _padding: 0.0,
+            // _padding: 0.0, // Removed duplicate
             st_shadow_hue: settings
                 .split_toning
                 .as_ref()
@@ -1067,7 +1067,7 @@ impl Renderer for WebGpuRenderer {
                 .unwrap_or(0.0),
             denoise_color: settings.denoise.as_ref().map(|d| d.color).unwrap_or(0.0),
             curves_intensity: settings.curves.as_ref().map(|c| c.intensity).unwrap_or(1.0),
-            _padding: 0.0,
+            // _padding: 0.0, // Removed duplicate
             st_shadow_hue: settings
                 .split_toning
                 .as_ref()
@@ -1093,8 +1093,10 @@ impl Renderer for WebGpuRenderer {
                 .as_ref()
                 .map(|s| s.balance)
                 .unwrap_or(0.0),
-            _padding2: 0.0,
-            _padding3: 0.0,
+            _padding: 0.0,
+            distortion_k1: settings.distortion.as_ref().map(|d| d.k1).unwrap_or(0.0),
+            distortion_k2: settings.distortion.as_ref().map(|d| d.k2).unwrap_or(0.0),
+            _padding_align: 0.0,
             hsl: {
                 let mut hsl_data = [[0.0f32; 4]; 8];
                 let centers = [

--- a/quickfix-renderer/src/webgpu.rs
+++ b/quickfix-renderer/src/webgpu.rs
@@ -1096,7 +1096,8 @@ impl Renderer for WebGpuRenderer {
             _padding: 0.0,
             distortion_k1: settings.distortion.as_ref().map(|d| d.k1).unwrap_or(0.0),
             distortion_k2: settings.distortion.as_ref().map(|d| d.k2).unwrap_or(0.0),
-            _padding_align: 0.0,
+            hsl_enabled: if settings.hsl.is_some() { 1.0 } else { 0.0 },
+
             hsl: {
                 let mut hsl_data = [[0.0f32; 4]; 8];
                 let centers = [

--- a/quickfix-renderer/src/webgpu.rs
+++ b/quickfix-renderer/src/webgpu.rs
@@ -36,9 +36,11 @@ struct SettingsUniform {
     st_highlight_hue: f32,
     st_highlight_sat: f32,
     st_balance: f32,
+    /// Padding to match WGSL alignment (144 bytes used + 1 padding + 2 distortion + 1 align = 160)
     _padding: f32,
-    _padding2: f32,
-    _padding3: f32,
+    distortion_k1: f32,
+    distortion_k2: f32,
+    _padding_align: f32,
     hsl: [[f32; 4]; 8],
 }
 
@@ -573,8 +575,10 @@ impl Renderer for WebGpuRenderer {
                 .as_ref()
                 .map(|s| s.balance)
                 .unwrap_or(0.0),
-            _padding2: 0.0,
-            _padding3: 0.0,
+            _padding: 0.0,
+            distortion_k1: settings.distortion.as_ref().map(|d| d.k1).unwrap_or(0.0),
+            distortion_k2: settings.distortion.as_ref().map(|d| d.k2).unwrap_or(0.0),
+            _padding_align: 0.0,
             hsl: {
                 let mut hsl_data = [[0.0f32; 4]; 8];
                 let centers = [

--- a/quickfix-renderer/src/webgpu.rs
+++ b/quickfix-renderer/src/webgpu.rs
@@ -31,7 +31,14 @@ struct SettingsUniform {
     denoise_luminance: f32,
     denoise_color: f32,
     curves_intensity: f32,
+    st_shadow_hue: f32,
+    st_shadow_sat: f32,
+    st_highlight_hue: f32,
+    st_highlight_sat: f32,
+    st_balance: f32,
     _padding: f32,
+    _padding2: f32,
+    _padding3: f32,
     hsl: [[f32; 4]; 8],
 }
 

--- a/quickfix-renderer/src/webgpu.rs
+++ b/quickfix-renderer/src/webgpu.rs
@@ -32,41 +32,7 @@ struct SettingsUniform {
     denoise_color: f32,
     curves_intensity: f32,
     _padding: f32,
-    // Previous: 16 floats exactly?
-    // geo (4), flip (4), crop_rot/asp/exp/cont (4), high/shad/temp/tint (4), grain/size/w/h (4).
-    // Total 20 floats?
-    // Let's recount.
-    // Matrix (12 floats, 4 padding in aligned vec3 cols?) -> 48 bytes.
-    // geo_padding (1) = 49th float? No matrix is separate.
-    // Struct:
-    // mat3x3 (48 bytes)
-    // geo_padding (4 bytes) -> offset 52
-    // flip_v (4) -> 56
-    // flip_h (4) -> 60
-    // crop_rot (4) -> 64
-    // crop_asp (4) -> 68
-    // exp (4) -> 72
-    // cont (4) -> 76
-    // high (4) -> 80
-    // shad (4) -> 84
-    // temp (4) -> 88
-    // tint (4) -> 92
-    // grain_amt (4) -> 96
-    // grain_sz (4) -> 100
-    // src_w (4) -> 104
-    // src_h (4) -> 108
-
-    // Now adding lut_intensity.
-    // lut_int (4) -> 112
-    // Struct alignment usually 16 bytes for uniform buffers.
-    // 112 is divisible by 16 (112 = 16 * 7).
-    // So we are good?
-    // Let's add padding just in case to match WGSL explicitly if needed, but WGSL is packed?
-    // WGSL `Settings` struct:
-    // ... src_width, src_height;
-    // lut_intensity;
-    // };
-    // WGSL struct size is implicitly padded to 16 bytes at end.
+    hsl: [[f32; 4]; 8],
 }
 
 pub struct WebGpuRenderer {
@@ -575,6 +541,42 @@ impl Renderer for WebGpuRenderer {
             denoise_color: settings.denoise.as_ref().map(|d| d.color).unwrap_or(0.0),
             curves_intensity: settings.curves.as_ref().map(|c| c.intensity).unwrap_or(1.0),
             _padding: 0.0,
+            hsl: {
+                let mut hsl_data = [[0.0f32; 4]; 8];
+                let centers = [
+                    0.0 / 360.0,
+                    30.0 / 360.0,
+                    60.0 / 360.0,
+                    120.0 / 360.0,
+                    180.0 / 360.0,
+                    240.0 / 360.0,
+                    270.0 / 360.0,
+                    300.0 / 360.0,
+                ];
+                if let Some(hsl) = &settings.hsl {
+                    let ranges = [
+                        &hsl.red,
+                        &hsl.orange,
+                        &hsl.yellow,
+                        &hsl.green,
+                        &hsl.aqua,
+                        &hsl.blue,
+                        &hsl.purple,
+                        &hsl.magenta,
+                    ];
+                    for i in 0..8 {
+                        hsl_data[i][0] = ranges[i].hue;
+                        hsl_data[i][1] = ranges[i].saturation;
+                        hsl_data[i][2] = ranges[i].luminance;
+                        hsl_data[i][3] = centers[i];
+                    }
+                } else {
+                    for i in 0..8 {
+                        hsl_data[i][3] = centers[i];
+                    }
+                }
+                hsl_data
+            },
         };
 
         let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -1028,6 +1030,42 @@ impl Renderer for WebGpuRenderer {
             denoise_color: settings.denoise.as_ref().map(|d| d.color).unwrap_or(0.0),
             curves_intensity: settings.curves.as_ref().map(|c| c.intensity).unwrap_or(1.0),
             _padding: 0.0,
+            hsl: {
+                let mut hsl_data = [[0.0f32; 4]; 8];
+                let centers = [
+                    0.0 / 360.0,
+                    30.0 / 360.0,
+                    60.0 / 360.0,
+                    120.0 / 360.0,
+                    180.0 / 360.0,
+                    240.0 / 360.0,
+                    270.0 / 360.0,
+                    300.0 / 360.0,
+                ];
+                if let Some(hsl) = &settings.hsl {
+                    let ranges = [
+                        &hsl.red,
+                        &hsl.orange,
+                        &hsl.yellow,
+                        &hsl.green,
+                        &hsl.aqua,
+                        &hsl.blue,
+                        &hsl.purple,
+                        &hsl.magenta,
+                    ];
+                    for i in 0..8 {
+                        hsl_data[i][0] = ranges[i].hue;
+                        hsl_data[i][1] = ranges[i].saturation;
+                        hsl_data[i][2] = ranges[i].luminance;
+                        hsl_data[i][3] = centers[i];
+                    }
+                } else {
+                    for i in 0..8 {
+                        hsl_data[i][3] = centers[i];
+                    }
+                }
+                hsl_data
+            },
         };
 
         let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {


### PR DESCRIPTION
- Implement HslSettings and HslRangeSettings structs in lib.rs
- Add CPU-based HSL adjustment logic with quadratic falloff in operations.rs
- Update WGSL and GLSL shaders with per-range HSL masking
- Integrate HSL uniform data in WebGL and WebGPU renderers
- Add comprehensive HSL tuning UI with 24 sliders to the minimal-viewer
- Fix TypeScript linting and ensure clean build with pixi run build

Refs: #35